### PR TITLE
Auto-updating Spryker modules on 2023-12-15 12:12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ docker
 # angular
 /.angular/cache
 /.angular
+
+integrator.lock

--- a/composer.json
+++ b/composer.json
@@ -241,6 +241,7 @@
         "spryker/product-offer-availabilities-rest-api": "^1.1.0",
         "spryker/product-offer-prices-rest-api": "^2.0.1",
         "spryker/product-offer-sales-rest-api": "^1.0.1",
+        "spryker/product-offer-service-point-storage-extension": "^1.0.0",
         "spryker/product-offer-shopping-lists-rest-api": "^1.0.0",
         "spryker/product-offers-rest-api": "^1.0.0",
         "spryker/product-option-cart-connector": "^7.1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -10178,20 +10178,20 @@
         },
         {
             "name": "spryker-shop/company-page",
-            "version": "2.23.0",
+            "version": "2.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/company-page.git",
-                "reference": "fa6f148e5a521e9072b17653dae634e6e60d526f"
+                "reference": "4b53458b1ec511a29620a6afdf6fc60b31ebc100"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/company-page/zipball/fa6f148e5a521e9072b17653dae634e6e60d526f",
-                "reference": "fa6f148e5a521e9072b17653dae634e6e60d526f",
+                "url": "https://api.github.com/repos/spryker-shop/company-page/zipball/4b53458b1ec511a29620a6afdf6fc60b31ebc100",
+                "reference": "4b53458b1ec511a29620a6afdf6fc60b31ebc100",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker-shop/checkout-page-extension": "^1.0.0",
                 "spryker-shop/customer-page-extension": "^1.5.0",
                 "spryker-shop/shop-application": "^1.0.0",
@@ -10247,9 +10247,9 @@
             ],
             "description": "CompanyPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/company-page/tree/2.23.0"
+                "source": "https://github.com/spryker-shop/company-page/tree/2.24.0"
             },
-            "time": "2023-06-16T12:23:11+00:00"
+            "time": "2023-12-01T13:40:05+00:00"
         },
         {
             "name": "spryker-shop/company-user-agent-widget",
@@ -25867,20 +25867,20 @@
         },
         {
             "name": "spryker/company-user",
-            "version": "2.16.1",
+            "version": "2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/company-user.git",
-                "reference": "d392c8e8bd2f9bd9c6438ee4fb55adffe7661273"
+                "reference": "a9523095a82906fa78affaee77ceec7a5580106f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/company-user/zipball/d392c8e8bd2f9bd9c6438ee4fb55adffe7661273",
-                "reference": "d392c8e8bd2f9bd9c6438ee4fb55adffe7661273",
+                "url": "https://api.github.com/repos/spryker/company-user/zipball/a9523095a82906fa78affaee77ceec7a5580106f",
+                "reference": "a9523095a82906fa78affaee77ceec7a5580106f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/company": "^1.0.0",
                 "spryker/company-extension": "^1.0.0",
                 "spryker/company-user-extension": "^1.2.0",
@@ -25888,7 +25888,7 @@
                 "spryker/kernel": "^3.30.0",
                 "spryker/permission-extension": "^1.0.0",
                 "spryker/propel-orm": "^1.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/zed-request": "^3.0.0"
             },
             "require-dev": {
@@ -25919,9 +25919,9 @@
             ],
             "description": "CompanyUser module",
             "support": {
-                "source": "https://github.com/spryker/company-user/tree/2.16.1"
+                "source": "https://github.com/spryker/company-user/tree/2.17.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-12-12T08:52:30+00:00"
         },
         {
             "name": "spryker/company-user-agent",

--- a/composer.lock
+++ b/composer.lock
@@ -58101,20 +58101,20 @@
         },
         {
             "name": "spryker/state-machine",
-            "version": "2.18.0",
+            "version": "2.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/state-machine.git",
-                "reference": "2736a095208d8837e100a00ec086091937a2e571"
+                "reference": "c14a7b53e43d223cbedd85ed2eed976041f93e28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/state-machine/zipball/2736a095208d8837e100a00ec086091937a2e571",
-                "reference": "2736a095208d8837e100a00ec086091937a2e571",
+                "url": "https://api.github.com/repos/spryker/state-machine/zipball/c14a7b53e43d223cbedd85ed2eed976041f93e28",
+                "reference": "c14a7b53e43d223cbedd85ed2eed976041f93e28",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/graph": "^3.0.0",
                 "spryker/kernel": "^3.30.0",
@@ -58122,6 +58122,7 @@
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-network": "^1.1.0",
+                "spryker/util-sanitize-xss": "^1.1.0",
                 "spryker/util-text": "^1.1.0"
             },
             "require-dev": {
@@ -58148,9 +58149,9 @@
             ],
             "description": "StateMachine module",
             "support": {
-                "source": "https://github.com/spryker/state-machine/tree/2.18.0"
+                "source": "https://github.com/spryker/state-machine/tree/2.20.0"
             },
-            "time": "2023-07-18T10:08:54+00:00"
+            "time": "2023-11-29T09:16:52+00:00"
         },
         {
             "name": "spryker/step-engine",

--- a/composer.lock
+++ b/composer.lock
@@ -9517,25 +9517,25 @@
         },
         {
             "name": "spryker-shop/checkout-page",
-            "version": "3.24.0",
+            "version": "3.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/checkout-page.git",
-                "reference": "c08bf59ca60686a4e7a110116cf10b20d0f4e451"
+                "reference": "ba9925b83389c071def075dbbb3d4c070f376683"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/c08bf59ca60686a4e7a110116cf10b20d0f4e451",
-                "reference": "c08bf59ca60686a4e7a110116cf10b20d0f4e451",
+                "url": "https://api.github.com/repos/spryker-shop/checkout-page/zipball/ba9925b83389c071def075dbbb3d4c070f376683",
+                "reference": "ba9925b83389c071def075dbbb3d4c070f376683",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
-                "spryker-shop/checkout-page-extension": "^1.4.0",
-                "spryker-shop/customer-page": "^2.13.0",
+                "php": ">=8.1",
+                "spryker-shop/checkout-page-extension": "^1.5.0",
+                "spryker-shop/customer-page": "^2.46.0",
                 "spryker-shop/money-widget": "^1.0.0",
                 "spryker-shop/shop-application": "^1.0.0",
-                "spryker-shop/shop-ui": "^1.40.0",
+                "spryker-shop/shop-ui": "^1.73.1",
                 "spryker/application": "^3.8.0",
                 "spryker/calculation": "^4.2.0",
                 "spryker/cart": "^4.3.0 || ^5.0.0 || ^7.0.0",
@@ -9574,13 +9574,15 @@
                 "spryker-shop/cart-code-widget": "If you want to use components from module CartCodeWidget or CheckoutVoucherFormWidget or CheckoutVoucherFormWidgetPlugin",
                 "spryker-shop/cart-note-widget": "If you want to use components from module CartNoteWidget or CartNoteQuoteItemNoteWidgetPlugin.",
                 "spryker-shop/checkout-widget": "Add the module if you want to use checkout widget",
-                "spryker-shop/company-widget": "Add the module if you want to use company widget",
+                "spryker-shop/company-widget": "Add the module if you want to use company widget, use the version >= 1.9.0",
                 "spryker-shop/configurable-bundle-widget": "Add the module if you want to use QuoteConfiguredBundleWidget.",
                 "spryker-shop/gift-card-widget": "Add the module if you want to use gift card widget",
                 "spryker-shop/merchant-widget": "If you want to use MerchantMetaSchemaWidget use the version >= 1.3.0",
                 "spryker-shop/order-custom-reference-widget": "Add the module if you want to use order custom reference functionality",
                 "spryker-shop/product-packaging-unit-widget": "If you want to use components from module ProductPackagingUnitWidget or SummaryProductPackagingUnitWidgetPlugin: ^0.5.2",
                 "spryker-shop/quote-request-widget": "If you want to use QuoteRequestActionsWidget: ^2.2.0",
+                "spryker-shop/service-point-widget": "Add the module if you want to use service point widget",
+                "spryker-shop/shipment-type-widget": "Add the module if you want to use ShipmentTypeAddressFormWidget.",
                 "spryker/router": "Use this module when you want to use the Router.",
                 "spryker/shipment-cart-connector": "If you want to use shipment totals in quote or shipment source prices, min version 2.1.0",
                 "spryker/silex": "Use this module when using plugins that need Silex dependencies."
@@ -9602,26 +9604,26 @@
             ],
             "description": "CheckoutPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/checkout-page/tree/3.24.0"
+                "source": "https://github.com/spryker-shop/checkout-page/tree/3.30.1"
             },
-            "time": "2023-03-31T19:36:14+00:00"
+            "time": "2023-12-14T10:12:44+00:00"
         },
         {
             "name": "spryker-shop/checkout-page-extension",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/checkout-page-extension.git",
-                "reference": "d7509366e15257de3677a868a59df2a5512b45f2"
+                "reference": "767a3361f78c0debe11188b397959808d9a47402"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/checkout-page-extension/zipball/d7509366e15257de3677a868a59df2a5512b45f2",
-                "reference": "d7509366e15257de3677a868a59df2a5512b45f2",
+                "url": "https://api.github.com/repos/spryker-shop/checkout-page-extension/zipball/767a3361f78c0debe11188b397959808d9a47402",
+                "reference": "767a3361f78c0debe11188b397959808d9a47402",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/step-engine-extension": "^1.0.0"
             },
             "require-dev": {
@@ -9649,9 +9651,9 @@
             ],
             "description": "CheckoutPageExtension module",
             "support": {
-                "source": "https://github.com/spryker-shop/checkout-page-extension/tree/1.4.0"
+                "source": "https://github.com/spryker-shop/checkout-page-extension/tree/1.5.0"
             },
-            "time": "2022-04-14T07:53:43+00:00"
+            "time": "2023-08-09T13:13:58+00:00"
         },
         {
             "name": "spryker-shop/checkout-widget",
@@ -10901,22 +10903,22 @@
         },
         {
             "name": "spryker-shop/customer-page",
-            "version": "2.43.0",
+            "version": "2.49.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/customer-page.git",
-                "reference": "93c8ae52879fa94ef1a325d7d5c841a7c9c4a169"
+                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/93c8ae52879fa94ef1a325d7d5c841a7c9c4a169",
-                "reference": "93c8ae52879fa94ef1a325d7d5c841a7c9c4a169",
+                "url": "https://api.github.com/repos/spryker-shop/customer-page/zipball/08ba64b07809edc26c5865c3289f50ccefeb744a",
+                "reference": "08ba64b07809edc26c5865c3289f50ccefeb744a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker-shop/checkout-page-extension": "^1.0.0",
-                "spryker-shop/customer-page-extension": "^1.5.0",
+                "spryker-shop/customer-page-extension": "^1.6.0",
                 "spryker-shop/shop-application": "^1.0.0",
                 "spryker-shop/shop-ui": "^1.70.0",
                 "spryker/application": "^3.8.0",
@@ -10927,11 +10929,13 @@
                 "spryker/quote": "^1.0.0 || ^2.1.0",
                 "spryker/router": "^1.6.0",
                 "spryker/sales": "^8.15.0 || ^10.0.0 || ^11.8.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/shipment": "^7.0.0 || ^8.0.0",
                 "spryker/step-engine": "^3.3.0",
                 "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.1.0",
+                "spryker/transfer": "^3.25.0",
                 "spryker/twig": "^3.18.0",
                 "spryker/twig-extension": "^1.0.0",
                 "spryker/util-validate": "^1.0.0"
@@ -10967,6 +10971,7 @@
                 "spryker-shop/sales-configurable-bundle-widget": "Add the module if you want to use OrderItemsConfiguredBundleWidget.",
                 "spryker-shop/sales-product-configuration-widget": "Add the module if you want to use ProductConfigurationOrderItemDisplayWidget.",
                 "spryker-shop/sales-return-page": "Add the module if you want to use return-create-link molecule.",
+                "spryker-shop/sales-service-point-widget": "Add the module if you want to display the service point related information.",
                 "spryker/config": "Use this module when using plugins that need Config dependencies.",
                 "spryker/container": "If you want to use twig plugins.",
                 "spryker/messenger": "Use this module when using plugins that need Messenger dependencies.",
@@ -10991,26 +10996,26 @@
             ],
             "description": "CustomerPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/customer-page/tree/2.43.0"
+                "source": "https://github.com/spryker-shop/customer-page/tree/2.49.0"
             },
-            "time": "2023-07-06T09:11:57+00:00"
+            "time": "2023-11-24T22:16:29+00:00"
         },
         {
             "name": "spryker-shop/customer-page-extension",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/customer-page-extension.git",
-                "reference": "ffac939bd3446bb08bea7c3ab207a270b1098da5"
+                "reference": "f0dba8b31c6a2592d4dcfcdb55b88ae23d3ca03b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/customer-page-extension/zipball/ffac939bd3446bb08bea7c3ab207a270b1098da5",
-                "reference": "ffac939bd3446bb08bea7c3ab207a270b1098da5",
+                "url": "https://api.github.com/repos/spryker-shop/customer-page-extension/zipball/f0dba8b31c6a2592d4dcfcdb55b88ae23d3ca03b",
+                "reference": "f0dba8b31c6a2592d4dcfcdb55b88ae23d3ca03b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
+                "php": ">=8.0",
                 "spryker/symfony": "^3.5.0"
             },
             "require-dev": {
@@ -11033,9 +11038,9 @@
             ],
             "description": "CustomerPageExtension module",
             "support": {
-                "source": "https://github.com/spryker-shop/customer-page-extension/tree/1.5.0"
+                "source": "https://github.com/spryker-shop/customer-page-extension/tree/1.6.0"
             },
-            "time": "2021-07-01T07:33:02+00:00"
+            "time": "2023-07-28T12:49:00+00:00"
         },
         {
             "name": "spryker-shop/customer-reorder-widget",
@@ -16335,20 +16340,20 @@
         },
         {
             "name": "spryker-shop/shop-ui",
-            "version": "1.71.0",
+            "version": "1.73.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/shop-ui.git",
-                "reference": "688ca5a02955d6443dbf2a192f0c0d052c3c7298"
+                "reference": "d3496765096314a42f83ec0dd69b47264f406e0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/shop-ui/zipball/688ca5a02955d6443dbf2a192f0c0d052c3c7298",
-                "reference": "688ca5a02955d6443dbf2a192f0c0d052c3c7298",
+                "url": "https://api.github.com/repos/spryker-shop/shop-ui/zipball/d3496765096314a42f83ec0dd69b47264f406e0f",
+                "reference": "d3496765096314a42f83ec0dd69b47264f406e0f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/form-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
@@ -16392,9 +16397,9 @@
             ],
             "description": "ShopUi module",
             "support": {
-                "source": "https://github.com/spryker-shop/shop-ui/tree/1.71.0"
+                "source": "https://github.com/spryker-shop/shop-ui/tree/1.73.2"
             },
-            "time": "2023-07-03T12:28:35+00:00"
+            "time": "2023-12-14T15:18:14+00:00"
         },
         {
             "name": "spryker-shop/shopping-list-note-widget",
@@ -28943,20 +28948,20 @@
         },
         {
             "name": "spryker/customer-access-storage",
-            "version": "1.8.1",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer-access-storage.git",
-                "reference": "2a95c28ada9b5d1ed9b50f6d89ed3e8b133d955e"
+                "reference": "b21aa28a9737e983f24f67a832d8792eb3358d7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer-access-storage/zipball/2a95c28ada9b5d1ed9b50f6d89ed3e8b133d955e",
-                "reference": "2a95c28ada9b5d1ed9b50f6d89ed3e8b133d955e",
+                "url": "https://api.github.com/repos/spryker/customer-access-storage/zipball/b21aa28a9737e983f24f67a832d8792eb3358d7b",
+                "reference": "b21aa28a9737e983f24f67a832d8792eb3358d7b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/customer-access": "^1.0.0",
                 "spryker/kernel": "^3.37.0",
                 "spryker/propel-orm": "^1.5.0",
@@ -28997,9 +29002,9 @@
             ],
             "description": "CustomerAccessStorage module",
             "support": {
-                "source": "https://github.com/spryker/customer-access-storage/tree/1.8.1"
+                "source": "https://github.com/spryker/customer-access-storage/tree/1.9.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/customer-catalog",
@@ -33841,16 +33846,16 @@
         },
         {
             "name": "spryker/merchant",
-            "version": "3.7.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/merchant.git",
-                "reference": "fc9043993bae8300d51667b6fc3480ea4959f13f"
+                "reference": "20a87db02ca3b188c94bb0a934cfe2dc1f676659"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/merchant/zipball/fc9043993bae8300d51667b6fc3480ea4959f13f",
-                "reference": "fc9043993bae8300d51667b6fc3480ea4959f13f",
+                "url": "https://api.github.com/repos/spryker/merchant/zipball/20a87db02ca3b188c94bb0a934cfe2dc1f676659",
+                "reference": "20a87db02ca3b188c94bb0a934cfe2dc1f676659",
                 "shasum": ""
             },
             "require": {
@@ -33861,7 +33866,7 @@
                 "spryker/event": "^2.3.0",
                 "spryker/kernel": "^3.33.0",
                 "spryker/log": "^3.0.0",
-                "spryker/merchant-extension": "^1.1.0",
+                "spryker/merchant-extension": "^1.2.0",
                 "spryker/message-broker": "^1.5.0",
                 "spryker/message-broker-extension": "^1.0.0",
                 "spryker/price-product-merchant-relationship-storage-extension": "^1.0.0",
@@ -33877,6 +33882,7 @@
                 "spryker/code-sniffer": "*",
                 "spryker/container": "*",
                 "spryker/propel": "*",
+                "spryker/ramsey-uuid": "*",
                 "spryker/testify": "*"
             },
             "type": "library",
@@ -33888,7 +33894,8 @@
             "autoload": {
                 "psr-4": {
                     "Spryker\\": "src/Spryker/",
-                    "SprykerTest\\Zed\\Merchant\\Helper\\": "tests/SprykerTest/Zed/Merchant/_support/Helper/"
+                    "SprykerTest\\Zed\\Merchant\\Helper\\": "tests/SprykerTest/Zed/Merchant/_support/Helper/",
+                    "SprykerTest\\AsyncApi\\Merchant\\Helper\\": "tests/SprykerTest/AsyncApi/Merchant/_support/Helper/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -33897,9 +33904,9 @@
             ],
             "description": "Merchant module",
             "support": {
-                "source": "https://github.com/spryker/merchant/tree/3.7.1"
+                "source": "https://github.com/spryker/merchant/tree/3.9.0"
             },
-            "time": "2023-06-16T09:24:47+00:00"
+            "time": "2023-08-21T15:35:01+00:00"
         },
         {
             "name": "spryker/merchant-categories-rest-api",
@@ -34152,20 +34159,20 @@
         },
         {
             "name": "spryker/merchant-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/merchant-extension.git",
-                "reference": "a2e8d29c2fbabdbf6ebc7d33d8eb498223a883bf"
+                "reference": "30c2b54e176698d7b70da27061f5f94e4ba77470"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/merchant-extension/zipball/a2e8d29c2fbabdbf6ebc7d33d8eb498223a883bf",
-                "reference": "a2e8d29c2fbabdbf6ebc7d33d8eb498223a883bf",
+                "url": "https://api.github.com/repos/spryker/merchant-extension/zipball/30c2b54e176698d7b70da27061f5f94e4ba77470",
+                "reference": "30c2b54e176698d7b70da27061f5f94e4ba77470",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=8.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -34187,9 +34194,9 @@
             ],
             "description": "MerchantExtension module",
             "support": {
-                "source": "https://github.com/spryker/merchant-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/merchant-extension/tree/1.2.0"
             },
-            "time": "2020-01-29T09:34:23+00:00"
+            "time": "2023-08-11T12:28:44+00:00"
         },
         {
             "name": "spryker/merchant-gui",
@@ -40410,16 +40417,16 @@
         },
         {
             "name": "spryker/payment",
-            "version": "5.14.1",
+            "version": "5.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/payment.git",
-                "reference": "3999cb4636d65f94c56733c99f9e43eb3aea6fcf"
+                "reference": "021492247441b948c4935042916a98c639a8f08d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/payment/zipball/3999cb4636d65f94c56733c99f9e43eb3aea6fcf",
-                "reference": "3999cb4636d65f94c56733c99f9e43eb3aea6fcf",
+                "url": "https://api.github.com/repos/spryker/payment/zipball/021492247441b948c4935042916a98c639a8f08d",
+                "reference": "021492247441b948c4935042916a98c639a8f08d",
                 "shasum": ""
             },
             "require": {
@@ -40474,9 +40481,9 @@
             ],
             "description": "Payment module",
             "support": {
-                "source": "https://github.com/spryker/payment/tree/5.14.1"
+                "source": "https://github.com/spryker/payment/tree/5.15.1"
             },
-            "time": "2023-06-16T09:24:47+00:00"
+            "time": "2023-10-17T13:19:18+00:00"
         },
         {
             "name": "spryker/payment-cart-connector",
@@ -41280,20 +41287,20 @@
         },
         {
             "name": "spryker/price-product",
-            "version": "4.42.1",
+            "version": "4.43.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/price-product.git",
-                "reference": "0ed071fad704b9608d9e67c42a70a0b7355ad17e"
+                "reference": "153c34eafe6fe1084f5bf5ae1a96e3583231625c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/price-product/zipball/0ed071fad704b9608d9e67c42a70a0b7355ad17e",
-                "reference": "0ed071fad704b9608d9e67c42a70a0b7355ad17e",
+                "url": "https://api.github.com/repos/spryker/price-product/zipball/153c34eafe6fe1084f5bf5ae1a96e3583231625c",
+                "reference": "153c34eafe6fe1084f5bf5ae1a96e3583231625c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/currency": "^3.10.0 || ^4.0.0",
                 "spryker/event": "^1.0.0 || ^2.0.0",
@@ -41346,9 +41353,9 @@
             ],
             "description": "PriceProduct module",
             "support": {
-                "source": "https://github.com/spryker/price-product/tree/4.42.1"
+                "source": "https://github.com/spryker/price-product/tree/4.43.1"
             },
-            "time": "2023-06-06T14:54:59+00:00"
+            "time": "2023-11-17T08:53:15+00:00"
         },
         {
             "name": "spryker/price-product-data-import",
@@ -43565,20 +43572,20 @@
         },
         {
             "name": "spryker/product-bundle",
-            "version": "7.15.0",
+            "version": "7.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-bundle.git",
-                "reference": "bbfb27b6444e89493bcb6bd58591ef88306e4368"
+                "reference": "0c84519ffa06963d4a76c5ec6604728739faf377"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-bundle/zipball/bbfb27b6444e89493bcb6bd58591ef88306e4368",
-                "reference": "bbfb27b6444e89493bcb6bd58591ef88306e4368",
+                "url": "https://api.github.com/repos/spryker/product-bundle/zipball/0c84519ffa06963d4a76c5ec6604728739faf377",
+                "reference": "0c84519ffa06963d4a76c5ec6604728739faf377",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/availability": "^9.8.0",
                 "spryker/calculation-extension": "^1.1.0",
                 "spryker/cart-extension": "^1.0.0 || ^2.0.0 || ^4.0.0",
@@ -43639,9 +43646,9 @@
             ],
             "description": "ProductBundle module",
             "support": {
-                "source": "https://github.com/spryker/product-bundle/tree/7.15.0"
+                "source": "https://github.com/spryker/product-bundle/tree/7.18.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-12-07T11:38:32+00:00"
         },
         {
             "name": "spryker/product-bundle-carts-rest-api",
@@ -55730,23 +55737,24 @@
         },
         {
             "name": "spryker/security-gui",
-            "version": "1.3.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-gui.git",
-                "reference": "a0ca717dec4f606c6293bf40087d41dc5549cf09"
+                "reference": "6ed419c3267d56e6bc91abea2268926943c28719"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-gui/zipball/a0ca717dec4f606c6293bf40087d41dc5549cf09",
-                "reference": "a0ca717dec4f606c6293bf40087d41dc5549cf09",
+                "url": "https://api.github.com/repos/spryker/security-gui/zipball/6ed419c3267d56e6bc91abea2268926943c28719",
+                "reference": "6ed419c3267d56e6bc91abea2268926943c28719",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/security": "^1.3.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/security-gui-extension": "^1.2.0",
                 "spryker/symfony": "^3.5.0",
@@ -55788,9 +55796,9 @@
             ],
             "description": "SecurityGui module",
             "support": {
-                "source": "https://github.com/spryker/security-gui/tree/1.3.0"
+                "source": "https://github.com/spryker/security-gui/tree/1.5.0"
             },
-            "time": "2023-03-03T10:26:17+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/security-gui-extension",
@@ -55835,25 +55843,26 @@
         },
         {
             "name": "spryker/security-merchant-portal-gui",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-merchant-portal-gui.git",
-                "reference": "b04d69d73b793a8afdf66ba057efb0682c22f65f"
+                "reference": "dddee33c56f44783e290d8a4d006202ec52a805e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui/zipball/b04d69d73b793a8afdf66ba057efb0682c22f65f",
-                "reference": "b04d69d73b793a8afdf66ba057efb0682c22f65f",
+                "url": "https://api.github.com/repos/spryker/security-merchant-portal-gui/zipball/dddee33c56f44783e290d8a4d006202ec52a805e",
+                "reference": "dddee33c56f44783e290d8a4d006202ec52a805e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.33.0",
                 "spryker/merchant-user": "^1.0.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/security": "^1.5.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/security-extension": "^1.0.0",
                 "spryker/security-merchant-portal-gui-extension": "^1.0.0",
                 "spryker/symfony": "^3.5.0",
@@ -55897,9 +55906,9 @@
             ],
             "description": "SecurityMerchantPortalGui module",
             "support": {
-                "source": "https://github.com/spryker/security-merchant-portal-gui/tree/2.1.0"
+                "source": "https://github.com/spryker/security-merchant-portal-gui/tree/2.2.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/security-merchant-portal-gui-extension",
@@ -60759,22 +60768,23 @@
         },
         {
             "name": "spryker/user-password-reset",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user-password-reset.git",
-                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450"
+                "reference": "9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/c2cbea430658f1d4a0b4f110018e43d4cdcac450",
-                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450",
+                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c",
+                "reference": "9b8df93135a0f0c6b88f54c0681dbe0a78e51f7c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
+                "spryker/propel-orm": "^1.0.0",
                 "spryker/transfer": "^3.27.0",
                 "spryker/user": "^3.17.0",
                 "spryker/user-password-reset-extension": "^1.0.0",
@@ -60802,9 +60812,9 @@
             ],
             "description": "UserPasswordReset module",
             "support": {
-                "source": "https://github.com/spryker/user-password-reset/tree/1.4.0"
+                "source": "https://github.com/spryker/user-password-reset/tree/1.5.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-11-24T22:16:26+00:00"
         },
         {
             "name": "spryker/user-password-reset-extension",
@@ -62323,16 +62333,16 @@
         },
         {
             "name": "spryker/zed-ui",
-            "version": "2.1.2",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-ui.git",
-                "reference": "dfbcea3506d470a6e6cb1803ae6b43f6365e11ef"
+                "reference": "68286df3a6d3006369403a369ca050b8dd28cdf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-ui/zipball/dfbcea3506d470a6e6cb1803ae6b43f6365e11ef",
-                "reference": "dfbcea3506d470a6e6cb1803ae6b43f6365e11ef",
+                "url": "https://api.github.com/repos/spryker/zed-ui/zipball/68286df3a6d3006369403a369ca050b8dd28cdf8",
+                "reference": "68286df3a6d3006369403a369ca050b8dd28cdf8",
                 "shasum": ""
             },
             "require": {
@@ -62372,9 +62382,9 @@
             ],
             "description": "ZedUi module",
             "support": {
-                "source": "https://github.com/spryker/zed-ui/tree/2.1.2"
+                "source": "https://github.com/spryker/zed-ui/tree/2.2.0"
             },
-            "time": "2023-05-29T09:03:54+00:00"
+            "time": "2023-09-12T13:38:42+00:00"
         },
         {
             "name": "stella-maris/clock",

--- a/composer.lock
+++ b/composer.lock
@@ -21193,16 +21193,16 @@
         },
         {
             "name": "spryker/chart",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/chart.git",
-                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b"
+                "reference": "96c11005add3af78dfc11baf0e7d60061104233d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/chart/zipball/d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
-                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
+                "url": "https://api.github.com/repos/spryker/chart/zipball/96c11005add3af78dfc11baf0e7d60061104233d",
+                "reference": "96c11005add3af78dfc11baf0e7d60061104233d",
                 "shasum": ""
             },
             "require": {
@@ -21239,9 +21239,9 @@
             ],
             "description": "Chart module",
             "support": {
-                "source": "https://github.com/spryker/chart/tree/1.5.0"
+                "source": "https://github.com/spryker/chart/tree/1.6.0"
             },
-            "time": "2023-10-09T14:30:57+00:00"
+            "time": "2023-11-01T12:11:03+00:00"
         },
         {
             "name": "spryker/chart-gui",

--- a/composer.lock
+++ b/composer.lock
@@ -465,16 +465,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
                 "shasum": ""
             },
             "require": {
@@ -524,9 +524,9 @@
                 "versioning"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
+                "source": "https://github.com/composer/semver/tree/3.4.0"
             },
             "funding": [
                 {
@@ -542,7 +542,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T19:23:25+00:00"
+            "time": "2023-08-31T09:50:34+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -613,16 +613,16 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
                 "shasum": ""
             },
             "require": {
@@ -654,9 +654,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.2"
             },
-            "time": "2023-06-03T09:27:29+00:00"
+            "time": "2023-09-27T20:04:15+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1255,22 +1255,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.7.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5"
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/41042bc7ab002487b876a0683fc8dce04ddce104",
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0",
-                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -1279,11 +1279,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1361,7 +1361,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.7.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1377,7 +1377,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T14:04:53+00:00"
+            "time": "2023-12-03T20:35:24+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1460,16 +1460,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.5.0",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221",
                 "shasum": ""
             },
             "require": {
@@ -1483,9 +1483,9 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1556,7 +1556,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.2"
             },
             "funding": [
                 {
@@ -1572,7 +1572,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:11:26+00:00"
+            "time": "2023-12-03T20:05:35+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1706,22 +1706,22 @@
         },
         {
             "name": "laminas/laminas-config",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-config.git",
-                "reference": "46baad58d0b12cf98539e04334eff40a1fdfb9a0"
+                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/46baad58d0b12cf98539e04334eff40a1fdfb9a0",
-                "reference": "46baad58d0b12cf98539e04334eff40a1fdfb9a0",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/e53717277f6c22b1c697a46473b9a5ec9a438efa",
+                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
@@ -1770,27 +1770,27 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-16T14:21:22+00:00"
+            "time": "2023-09-19T12:02:54+00:00"
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.31.0",
+            "version": "2.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8"
+                "reference": "6ad64828d25ec4bdf226ec5096aabb04aa710324"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/6ad64828d25ec4bdf226ec5096aabb04aa710324",
+                "reference": "6ad64828d25ec4bdf226ec5096aabb04aa710324",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^3.14.0",
+                "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.13.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "laminas/laminas-validator": "<2.10.1",
@@ -1798,13 +1798,14 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-crypt": "^3.9",
-                "laminas/laminas-uri": "^2.10",
+                "laminas/laminas-crypt": "^3.10",
+                "laminas/laminas-i18n": "^2.23.1",
+                "laminas/laminas-uri": "^2.11",
                 "pear/archive_tar": "^1.4.14",
-                "phpunit/phpunit": "^9.5.27",
+                "phpunit/phpunit": "^10.4.2",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^5.3"
+                "psr/http-factory": "^1.0.2",
+                "vimeo/psalm": "^5.15.0"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -1848,30 +1849,30 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-12T06:17:48+00:00"
+            "time": "2023-11-03T13:29:10+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.20.0",
+            "version": "3.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+                "reference": "de98d297d4743956a0558a6d71616979ff779328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/de98d297d4743956a0558a6d71616979ff779328",
+                "reference": "de98d297d4743956a0558a6d71616979ff779328",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "laminas/laminas-stdlib": "^3.17",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "ext-psr": "*",
-                "laminas/laminas-code": "<3.3.1",
+                "laminas/laminas-code": "<4.10.0",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
@@ -1883,18 +1884,18 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.14",
+                "laminas/laminas-code": "^4.10.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
-                "laminas/laminas-dependency-plugin": "^2.2",
-                "mikey179/vfsstream": "^1.6.11@alpha",
-                "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.4",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8.0"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
             },
             "bin": [
                 "bin/generate-deps-for-config-factory",
@@ -1938,34 +1939,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-01T17:03:38+00:00"
+            "time": "2023-10-24T11:19:47+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
+                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.14",
+                "phpunit/phpunit": "^10.3.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.15.0"
             },
             "type": "library",
             "autoload": {
@@ -1997,7 +1998,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-09-19T10:15:21+00:00"
         },
         {
             "name": "laminas/laminas-validator",
@@ -2221,34 +2222,39 @@
         },
         {
             "name": "league/csv",
-            "version": "9.8.0",
+            "version": "9.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47"
+                "reference": "c1dc31e23eb3cd0f7b537ee1a669d5f58d5cfe21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
-                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/c1dc31e23eb3cd0f7b537ee1a669d5f58d5cfe21",
+                "reference": "c1dc31e23eb3cd0f7b537ee1a669d5f58d5cfe21",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.4 || ^8.0"
+                "php": "^8.1.2"
             },
             "require-dev": {
-                "ext-curl": "*",
+                "doctrine/collections": "^2.1.4",
                 "ext-dom": "*",
-                "friendsofphp/php-cs-fixer": "^v3.4.0",
-                "phpstan/phpstan": "^1.3.0",
-                "phpstan/phpstan-phpunit": "^1.0.0",
-                "phpstan/phpstan-strict-rules": "^1.1.0",
-                "phpunit/phpunit": "^9.5.11"
+                "ext-xdebug": "*",
+                "friendsofphp/php-cs-fixer": "^v3.22.0",
+                "phpbench/phpbench": "^1.2.15",
+                "phpstan/phpstan": "^1.10.46",
+                "phpstan/phpstan-deprecation-rules": "^1.1.4",
+                "phpstan/phpstan-phpunit": "^1.3.15",
+                "phpstan/phpstan-strict-rules": "^1.5.2",
+                "phpunit/phpunit": "^10.4.2",
+                "symfony/var-dumper": "^6.4.0"
             },
             "suggest": {
-                "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
+                "ext-dom": "Required to use the XMLConverter and the HTMLConverter classes",
                 "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
             },
             "type": "library",
@@ -2301,7 +2307,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-04T00:13:07+00:00"
+            "time": "2023-12-01T17:54:07+00:00"
         },
         {
             "name": "league/event",
@@ -2979,16 +2985,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1"
+                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
+                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
                 "shasum": ""
             },
             "require": {
@@ -3065,7 +3071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.9.1"
+                "source": "https://github.com/Seldaek/monolog/tree/2.9.2"
             },
             "funding": [
                 {
@@ -3077,7 +3083,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-06T13:44:46+00:00"
+            "time": "2023-10-27T15:25:26+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -3901,16 +3907,16 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
@@ -3947,9 +3953,9 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-client"
             },
-            "time": "2023-04-10T20:12:12+00:00"
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -4244,16 +4250,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.4",
+            "version": "4.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "60a4c63ab724854332900504274f6150ff26d286"
+                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/60a4c63ab724854332900504274f6150ff26d286",
-                "reference": "60a4c63ab724854332900504274f6150ff26d286",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
+                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
                 "shasum": ""
             },
             "require": {
@@ -4320,7 +4326,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.4"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.5"
             },
             "funding": [
                 {
@@ -4332,27 +4338,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-15T23:01:58+00:00"
+            "time": "2023-11-08T05:53:05+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.10.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38"
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
-                "reference": "f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/1a8460931ea36dc5c76838fec5734d55c88c6831",
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -4396,7 +4402,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.10.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.11.0"
             },
             "funding": [
                 {
@@ -4404,7 +4410,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-05-02T15:15:43+00:00"
+            "time": "2023-11-16T16:16:50+00:00"
         },
         {
             "name": "riskio/oauth2-auth0",
@@ -8362,16 +8368,16 @@
         },
         {
             "name": "spryker-sdk/evaluator",
-            "version": "0.1.3",
+            "version": "0.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-sdk/evaluator.git",
-                "reference": "3a4b3c85c00aea0514a98367317b4929ad7f6318"
+                "reference": "cdd63f1a0b44ec82f37d1644f9981cf93d9a357a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/evaluator/zipball/3a4b3c85c00aea0514a98367317b4929ad7f6318",
-                "reference": "3a4b3c85c00aea0514a98367317b4929ad7f6318",
+                "url": "https://api.github.com/repos/spryker-sdk/evaluator/zipball/cdd63f1a0b44ec82f37d1644f9981cf93d9a357a",
+                "reference": "cdd63f1a0b44ec82f37d1644f9981cf93d9a357a",
                 "shasum": ""
             },
             "require": {
@@ -8382,6 +8388,7 @@
                 "guzzlehttp/guzzle": "^7.5",
                 "php": ">=7.4",
                 "spryker-sdk/security-checker": "^0.2.0",
+                "spryker-sdk/utils": "^0.1.1",
                 "symfony/console": "^5.4|^6.0",
                 "symfony/dotenv": "^5.4|^6.0",
                 "symfony/filesystem": "^5.4|^6.0",
@@ -8430,9 +8437,9 @@
             "description": "The tool for evaluating Spryker shops",
             "support": {
                 "issues": "https://github.com/spryker-sdk/evaluator/issues",
-                "source": "https://github.com/spryker-sdk/evaluator/tree/0.1.3"
+                "source": "https://github.com/spryker-sdk/evaluator/tree/0.1.15"
             },
-            "time": "2023-07-25T09:03:46+00:00"
+            "time": "2023-11-16T15:12:17+00:00"
         },
         {
             "name": "spryker-sdk/security-checker",
@@ -8481,6 +8488,53 @@
                 "source": "https://github.com/spryker-sdk/security-checker/tree/0.2.0"
             },
             "time": "2023-04-24T11:24:18+00:00"
+        },
+        {
+            "name": "spryker-sdk/utils",
+            "version": "0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker-sdk/utils.git",
+                "reference": "a8db5e53e71a39fc94ed8105e2ec78be5c88e9e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker-sdk/utils/zipball/a8db5e53e71a39fc94ed8105e2ec78be5c88e9e2",
+                "reference": "a8db5e53e71a39fc94ed8105e2ec78be5c88e9e2",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^3.4",
+                "ext-mbstring": "*",
+                "laminas/laminas-filter": "^2.22.0",
+                "php": ">=7.4",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/filesystem": "^5.4.0 || ^6.0.0",
+                "symfony/finder": "^5.4.0 || ^6.0.0",
+                "symfony/process": "^5.4.0 || ^6.0.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "phpstan/phpstan": "^1.0.0",
+                "phpunit/phpunit": "^9.5.0",
+                "spryker/code-sniffer": "0.17.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SprykerSdk\\Utils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "Spryker SDK Utils Module",
+            "support": {
+                "issues": "https://github.com/spryker-sdk/utils/issues",
+                "source": "https://github.com/spryker-sdk/utils/tree/0.1.2"
+            },
+            "time": "2023-12-04T17:07:52+00:00"
         },
         {
             "name": "spryker-shop/agent-page",
@@ -16840,20 +16894,20 @@
         },
         {
             "name": "spryker/acl",
-            "version": "3.17.1",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/acl.git",
-                "reference": "df25104e32fe82691e34e405b0d2a034c32a6800"
+                "reference": "0e440cb5627f4db71a904c4f40256ca901430099"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/acl/zipball/df25104e32fe82691e34e405b0d2a034c32a6800",
-                "reference": "df25104e32fe82691e34e405b0d2a034c32a6800",
+                "url": "https://api.github.com/repos/spryker/acl/zipball/0e440cb5627f4db71a904c4f40256ca901430099",
+                "reference": "0e440cb5627f4db71a904c4f40256ca901430099",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-extension": "^1.1.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/config": "^3.0.0",
@@ -16909,9 +16963,9 @@
             ],
             "description": "Acl module",
             "support": {
-                "source": "https://github.com/spryker/acl/tree/3.17.1"
+                "source": "https://github.com/spryker/acl/tree/3.18.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/acl-data-import",
@@ -17546,20 +17600,20 @@
         },
         {
             "name": "spryker/application",
-            "version": "3.32.1",
+            "version": "3.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/application.git",
-                "reference": "86c27e0e946f0ffcd3bcc52a7f223dea8c30bfc8"
+                "reference": "13e11fc1ed0e88968961d05deb4dd5c1788bbedc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/application/zipball/86c27e0e946f0ffcd3bcc52a7f223dea8c30bfc8",
-                "reference": "86c27e0e946f0ffcd3bcc52a7f223dea8c30bfc8",
+                "url": "https://api.github.com/repos/spryker/application/zipball/13e11fc1ed0e88968961d05deb4dd5c1788bbedc",
+                "reference": "13e11fc1ed0e88968961d05deb4dd5c1788bbedc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.1.0",
                 "spryker/config": "^3.0.0",
                 "spryker/container": "^1.4.3",
@@ -17569,7 +17623,7 @@
                 "spryker/log": "^3.1.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/propel-orm": "^1.0.0",
-                "spryker/symfony": "^3.5.0",
+                "spryker/symfony": "^3.9.0",
                 "spryker/twig": "^3.13.0",
                 "spryker/twig-extension": "^1.0.0",
                 "spryker/util-encoding": "^2.0.0",
@@ -17607,9 +17661,9 @@
             ],
             "description": "Application module",
             "support": {
-                "source": "https://github.com/spryker/application/tree/3.32.1"
+                "source": "https://github.com/spryker/application/tree/3.35.0"
             },
-            "time": "2023-06-30T14:52:52+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/application-extension",
@@ -18113,20 +18167,20 @@
         },
         {
             "name": "spryker/authorization-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/authorization-extension.git",
-                "reference": "86e7a1fc12d2c4cf21d84648f483516712782f78"
+                "reference": "14e172c4448ea2a96dc7db4477d499eb99ab2edf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/authorization-extension/zipball/86e7a1fc12d2c4cf21d84648f483516712782f78",
-                "reference": "86e7a1fc12d2c4cf21d84648f483516712782f78",
+                "url": "https://api.github.com/repos/spryker/authorization-extension/zipball/14e172c4448ea2a96dc7db4477d499eb99ab2edf",
+                "reference": "14e172c4448ea2a96dc7db4477d499eb99ab2edf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -18148,29 +18202,30 @@
             ],
             "description": "AuthorizationExtension module",
             "support": {
-                "source": "https://github.com/spryker/authorization-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/authorization-extension/tree/1.2.0"
             },
-            "time": "2022-06-27T10:26:17+00:00"
+            "time": "2023-11-17T09:59:17+00:00"
         },
         {
             "name": "spryker/availability",
-            "version": "9.18.0",
+            "version": "9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/availability.git",
-                "reference": "8b69d070335433a1483934cc65cd798c6e98a510"
+                "reference": "8aaecdb24d48de99930017b4b9d8f312e5989fb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/availability/zipball/8b69d070335433a1483934cc65cd798c6e98a510",
-                "reference": "8b69d070335433a1483934cc65cd798c6e98a510",
+                "url": "https://api.github.com/repos/spryker/availability/zipball/8aaecdb24d48de99930017b4b9d8f312e5989fb5",
+                "reference": "8aaecdb24d48de99930017b4b9d8f312e5989fb5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/availability-extension": "^1.2.0",
                 "spryker/decimal-object": "^1.0.0",
+                "spryker/dynamic-entity-extension": "^1.0.0",
                 "spryker/event": "^2.3.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.0.0",
@@ -18186,7 +18241,7 @@
                 "spryker/storage": "^3.0.0",
                 "spryker/store": "^1.19.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/wishlist-extension": "^1.2.0",
                 "spryker/zed-request": "^3.0.0"
             },
@@ -18219,9 +18274,9 @@
             ],
             "description": "Availability module",
             "support": {
-                "source": "https://github.com/spryker/availability/tree/9.18.0"
+                "source": "https://github.com/spryker/availability/tree/9.21.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-17T11:31:39+00:00"
         },
         {
             "name": "spryker/availability-cart-connector",
@@ -20393,20 +20448,20 @@
         },
         {
             "name": "spryker/category",
-            "version": "5.13.0",
+            "version": "5.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/category.git",
-                "reference": "aca6a3df5617e5daab1daf68892dbcc3da10c249"
+                "reference": "05ab0400bdc8666aef4e0cb14be4df7a129763a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/category/zipball/aca6a3df5617e5daab1daf68892dbcc3da10c249",
-                "reference": "aca6a3df5617e5daab1daf68892dbcc3da10c249",
+                "url": "https://api.github.com/repos/spryker/category/zipball/05ab0400bdc8666aef4e0cb14be4df7a129763a8",
+                "reference": "05ab0400bdc8666aef4e0cb14be4df7a129763a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/category-extension": "^1.2.0",
                 "spryker/event": "^2.3.0",
@@ -20444,9 +20499,9 @@
             ],
             "description": "Category module",
             "support": {
-                "source": "https://github.com/spryker/category/tree/5.13.0"
+                "source": "https://github.com/spryker/category/tree/5.15.1"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-12-07T16:08:04+00:00"
         },
         {
             "name": "spryker/category-data-feed",
@@ -21138,16 +21193,16 @@
         },
         {
             "name": "spryker/chart",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/chart.git",
-                "reference": "095eb5c356c8513f5def6199a25e7ac487b7e111"
+                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/chart/zipball/095eb5c356c8513f5def6199a25e7ac487b7e111",
-                "reference": "095eb5c356c8513f5def6199a25e7ac487b7e111",
+                "url": "https://api.github.com/repos/spryker/chart/zipball/d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
+                "reference": "d5c0f89fd8467a8217c44505a6082b24f9e1d26b",
                 "shasum": ""
             },
             "require": {
@@ -21184,9 +21239,9 @@
             ],
             "description": "Chart module",
             "support": {
-                "source": "https://github.com/spryker/chart/tree/1.4.0"
+                "source": "https://github.com/spryker/chart/tree/1.5.0"
             },
-            "time": "2023-04-06T11:39:54+00:00"
+            "time": "2023-10-09T14:30:57+00:00"
         },
         {
             "name": "spryker/chart-gui",
@@ -21242,20 +21297,20 @@
         },
         {
             "name": "spryker/checkout",
-            "version": "6.4.4",
+            "version": "6.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/checkout.git",
-                "reference": "d41c58ffe3e445a21b81abc2422e5f0b72692939"
+                "reference": "7da945f4c9cf9902ca64d2d9dfbe1300a2602edc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/checkout/zipball/d41c58ffe3e445a21b81abc2422e5f0b72692939",
-                "reference": "d41c58ffe3e445a21b81abc2422e5f0b72692939",
+                "url": "https://api.github.com/repos/spryker/checkout/zipball/7da945f4c9cf9902ca64d2d9dfbe1300a2602edc",
+                "reference": "7da945f4c9cf9902ca64d2d9dfbe1300a2602edc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/checkout-extension": "^1.4.0",
                 "spryker/error-handler": "^2.1.0",
                 "spryker/kernel": "^3.30.0",
@@ -21297,9 +21352,9 @@
             ],
             "description": "Checkout module",
             "support": {
-                "source": "https://github.com/spryker/checkout/tree/6.4.4"
+                "source": "https://github.com/spryker/checkout/tree/6.5.0"
             },
-            "time": "2023-05-05T18:20:59+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/checkout-extension",
@@ -23985,20 +24040,20 @@
         },
         {
             "name": "spryker/collector",
-            "version": "6.8.0",
+            "version": "6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/collector.git",
-                "reference": "e5e8e980cb28843f59d978b670248c67cbdf9d0a"
+                "reference": "7feff69a52ac4d8d0308eb63490d0c7cfaa8b473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/collector/zipball/e5e8e980cb28843f59d978b670248c67cbdf9d0a",
-                "reference": "e5e8e980cb28843f59d978b670248c67cbdf9d0a",
+                "url": "https://api.github.com/repos/spryker/collector/zipball/7feff69a52ac4d8d0308eb63490d0c7cfaa8b473",
+                "reference": "7feff69a52ac4d8d0308eb63490d0c7cfaa8b473",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/config": "^3.0.0",
                 "spryker/elastica": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
                 "spryker/gui": "^3.0.0",
@@ -24040,9 +24095,9 @@
             ],
             "description": "Collector module",
             "support": {
-                "source": "https://github.com/spryker/collector/tree/6.8.0"
+                "source": "https://github.com/spryker/collector/tree/6.10.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-12-07T10:59:51+00:00"
         },
         {
             "name": "spryker/comment",
@@ -26386,20 +26441,20 @@
         },
         {
             "name": "spryker/config",
-            "version": "3.6.0",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/config.git",
-                "reference": "32b617980b9cecb49277e6ba0d985e75fc491a99"
+                "reference": "93663480ca5813839abd194df3636d605042817f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/config/zipball/32b617980b9cecb49277e6ba0d985e75fc491a99",
-                "reference": "32b617980b9cecb49277e6ba0d985e75fc491a99",
+                "url": "https://api.github.com/repos/spryker/config/zipball/93663480ca5813839abd194df3636d605042817f",
+                "reference": "93663480ca5813839abd194df3636d605042817f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.48.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/web-profiler-extension": "^1.0.0"
@@ -26435,9 +26490,9 @@
             ],
             "description": "Config module",
             "support": {
-                "source": "https://github.com/spryker/config/tree/3.6.0"
+                "source": "https://github.com/spryker/config/tree/3.7.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/configurable-bundle",
@@ -28620,25 +28675,25 @@
         },
         {
             "name": "spryker/customer",
-            "version": "7.51.4",
+            "version": "7.54.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer.git",
-                "reference": "5986c56d94e35fa3b332a4dbb700efb4ef1f54f4"
+                "reference": "641309603e0e20d48b134a60b0fa7708b12437fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer/zipball/5986c56d94e35fa3b332a4dbb700efb4ef1f54f4",
-                "reference": "5986c56d94e35fa3b332a4dbb700efb4ef1f54f4",
+                "url": "https://api.github.com/repos/spryker/customer/zipball/641309603e0e20d48b134a60b0fa7708b12437fb",
+                "reference": "641309603e0e20d48b134a60b0fa7708b12437fb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/authorization-extension": "^1.0.0",
                 "spryker/checkout-extension": "^1.2.0",
                 "spryker/country": "^3.1.0 || ^4.0.0",
-                "spryker/customer-extension": "^1.4.0",
+                "spryker/customer-extension": "^1.5.0",
                 "spryker/gui": "^3.39.0",
                 "spryker/kernel": "^3.72.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
@@ -28696,9 +28751,9 @@
             ],
             "description": "Customer module",
             "support": {
-                "source": "https://github.com/spryker/customer/tree/7.51.4"
+                "source": "https://github.com/spryker/customer/tree/7.54.0"
             },
-            "time": "2023-07-12T07:56:12+00:00"
+            "time": "2023-12-11T16:59:08+00:00"
         },
         {
             "name": "spryker/customer-access",
@@ -28997,20 +29052,20 @@
         },
         {
             "name": "spryker/customer-extension",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer-extension.git",
-                "reference": "c2f0fdbae3479968b3ef297fe7371aeb0ae5b503"
+                "reference": "83d918f0babe10ce1afb85bbbcf9f1fa2ba73c20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer-extension/zipball/c2f0fdbae3479968b3ef297fe7371aeb0ae5b503",
-                "reference": "c2f0fdbae3479968b3ef297fe7371aeb0ae5b503",
+                "url": "https://api.github.com/repos/spryker/customer-extension/zipball/83d918f0babe10ce1afb85bbbcf9f1fa2ba73c20",
+                "reference": "83d918f0babe10ce1afb85bbbcf9f1fa2ba73c20",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -29032,9 +29087,9 @@
             ],
             "description": "CustomerExtension module",
             "support": {
-                "source": "https://github.com/spryker/customer-extension/tree/1.4.0"
+                "source": "https://github.com/spryker/customer-extension/tree/1.5.0"
             },
-            "time": "2022-07-11T13:46:05+00:00"
+            "time": "2023-12-11T16:59:08+00:00"
         },
         {
             "name": "spryker/customer-group",
@@ -29918,20 +29973,20 @@
         },
         {
             "name": "spryker/discount",
-            "version": "9.34.0",
+            "version": "9.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/discount.git",
-                "reference": "833af3d4e77526156eb6913a5a867682d23839ef"
+                "reference": "c02f8db4149d97167023380c619b21dbd8f22d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/discount/zipball/833af3d4e77526156eb6913a5a867682d23839ef",
-                "reference": "833af3d4e77526156eb6913a5a867682d23839ef",
+                "url": "https://api.github.com/repos/spryker/discount/zipball/c02f8db4149d97167023380c619b21dbd8f22d72",
+                "reference": "c02f8db4149d97167023380c619b21dbd8f22d72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/cart-code-extension": "^1.1.0",
                 "spryker/cart-extension": "^1.0.0 || ^2.0.0 || ^4.0.0",
@@ -29990,9 +30045,9 @@
             ],
             "description": "Discount module",
             "support": {
-                "source": "https://github.com/spryker/discount/tree/9.34.0"
+                "source": "https://github.com/spryker/discount/tree/9.35.0"
             },
-            "time": "2023-06-22T08:06:14+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/discount-calculation-connector",
@@ -30677,6 +30732,48 @@
             "time": "2022-05-16T14:55:23+00:00"
         },
         {
+            "name": "spryker/dynamic-entity-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/dynamic-entity-extension.git",
+                "reference": "bf84f58deb3dc0135ded9e91e19d58c53e02fc34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/dynamic-entity-extension/zipball/bf84f58deb3dc0135ded9e91e19d58c53e02fc34",
+                "reference": "bf84f58deb3dc0135ded9e91e19d58c53e02fc34",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "DynamicEntityExtension module",
+            "support": {
+                "source": "https://github.com/spryker/dynamic-entity-extension/tree/1.0.0"
+            },
+            "time": "2023-09-19T09:44:37+00:00"
+        },
+        {
             "name": "spryker/egulias",
             "version": "1.1.1",
             "source": {
@@ -30839,16 +30936,16 @@
         },
         {
             "name": "spryker/error-handler",
-            "version": "2.8.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/error-handler.git",
-                "reference": "5b14f726e8c56ba1ffc66e7b216cb5664cdf4bdb"
+                "reference": "a7df6c890b36982e0eaab1a65aa071d3c46c8236"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/error-handler/zipball/5b14f726e8c56ba1ffc66e7b216cb5664cdf4bdb",
-                "reference": "5b14f726e8c56ba1ffc66e7b216cb5664cdf4bdb",
+                "url": "https://api.github.com/repos/spryker/error-handler/zipball/a7df6c890b36982e0eaab1a65aa071d3c46c8236",
+                "reference": "a7df6c890b36982e0eaab1a65aa071d3c46c8236",
                 "shasum": ""
             },
             "require": {
@@ -30894,9 +30991,9 @@
             ],
             "description": "ErrorHandler module",
             "support": {
-                "source": "https://github.com/spryker/error-handler/tree/2.8.1"
+                "source": "https://github.com/spryker/error-handler/tree/2.9.0"
             },
-            "time": "2023-04-06T07:18:59+00:00"
+            "time": "2023-10-23T13:54:19+00:00"
         },
         {
             "name": "spryker/error-handler-extension",
@@ -30997,20 +31094,20 @@
         },
         {
             "name": "spryker/event-behavior",
-            "version": "1.25.0",
+            "version": "1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/event-behavior.git",
-                "reference": "7ba0b48d8536077d39ad7b165ef606d609ed0965"
+                "reference": "b16d0be5f191e84393df990050fa5ea229a954db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/event-behavior/zipball/7ba0b48d8536077d39ad7b165ef606d609ed0965",
-                "reference": "7ba0b48d8536077d39ad7b165ef606d609ed0965",
+                "url": "https://api.github.com/repos/spryker/event-behavior/zipball/b16d0be5f191e84393df990050fa5ea229a954db",
+                "reference": "b16d0be5f191e84393df990050fa5ea229a954db",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/event": "^2.4.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/kernel": "^3.49.0",
@@ -31068,7 +31165,7 @@
             "support": {
                 "source": "https://github.com/spryker/event-behavior"
             },
-            "time": "2023-03-07T11:00:47+00:00"
+            "time": "2023-11-16T13:02:56+00:00"
         },
         {
             "name": "spryker/event-dispatcher",
@@ -31722,20 +31819,20 @@
         },
         {
             "name": "spryker/glossary",
-            "version": "3.14.0",
+            "version": "3.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glossary.git",
-                "reference": "31968a9b30ccc6465903d4188af9d31568e56b64"
+                "reference": "400a2ad7a70b21c39db5eb79c0fbad63ddf4595e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glossary/zipball/31968a9b30ccc6465903d4188af9d31568e56b64",
-                "reference": "31968a9b30ccc6465903d4188af9d31568e56b64",
+                "url": "https://api.github.com/repos/spryker/glossary/zipball/400a2ad7a70b21c39db5eb79c0fbad63ddf4595e",
+                "reference": "400a2ad7a70b21c39db5eb79c0fbad63ddf4595e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/gui": "^3.0.0",
                 "spryker/kernel": "^3.52.0",
@@ -31747,7 +31844,7 @@
                 "spryker/storage": "^3.0.0",
                 "spryker/symfony": "^3.5.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-text": "^1.1.0"
             },
             "require-dev": {
@@ -31788,22 +31885,22 @@
             ],
             "description": "Glossary module",
             "support": {
-                "source": "https://github.com/spryker/glossary/tree/3.14.0"
+                "source": "https://github.com/spryker/glossary/tree/3.16.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-27T15:01:56+00:00"
         },
         {
             "name": "spryker/glossary-storage",
-            "version": "1.11.1",
+            "version": "1.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glossary-storage.git",
-                "reference": "7fcba040efc7cdde734c4e8d4357561ca58b9ba2"
+                "reference": "d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glossary-storage/zipball/7fcba040efc7cdde734c4e8d4357561ca58b9ba2",
-                "reference": "7fcba040efc7cdde734c4e8d4357561ca58b9ba2",
+                "url": "https://api.github.com/repos/spryker/glossary-storage/zipball/d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf",
+                "reference": "d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf",
                 "shasum": ""
             },
             "require": {
@@ -31851,9 +31948,9 @@
             ],
             "description": "GlossaryStorage module",
             "support": {
-                "source": "https://github.com/spryker/glossary-storage/tree/1.11.1"
+                "source": "https://github.com/spryker/glossary-storage/tree/1.11.2"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-10-18T17:03:23+00:00"
         },
         {
             "name": "spryker/glue-application",
@@ -32576,20 +32673,20 @@
         },
         {
             "name": "spryker/gui",
-            "version": "3.49.2",
+            "version": "3.52.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/gui.git",
-                "reference": "e9f0c145a7064d1bbdbf6ac89a7295b21bed3632"
+                "reference": "c44699f1197d4754647a283f71da37ec20f8f376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/gui/zipball/e9f0c145a7064d1bbdbf6ac89a7295b21bed3632",
-                "reference": "e9f0c145a7064d1bbdbf6ac89a7295b21bed3632",
+                "url": "https://api.github.com/repos/spryker/gui/zipball/c44699f1197d4754647a283f71da37ec20f8f376",
+                "reference": "c44699f1197d4754647a283f71da37ec20f8f376",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/form-extension": "^1.0.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/laminas": "^1.0.0",
@@ -32634,9 +32731,9 @@
             ],
             "description": "Gui module",
             "support": {
-                "source": "https://github.com/spryker/gui/tree/3.49.2"
+                "source": "https://github.com/spryker/gui/tree/3.52.1"
             },
-            "time": "2023-04-06T07:25:58+00:00"
+            "time": "2023-11-28T14:08:58+00:00"
         },
         {
             "name": "spryker/gui-table",
@@ -33029,20 +33126,20 @@
         },
         {
             "name": "spryker/installer",
-            "version": "4.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/installer.git",
-                "reference": "808cf76da76f548c0f1603270439489fa9bc6736"
+                "reference": "cd2743f1db0d7f0f9f646657477b322b5e0704f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/installer/zipball/808cf76da76f548c0f1603270439489fa9bc6736",
-                "reference": "808cf76da76f548c0f1603270439489fa9bc6736",
+                "url": "https://api.github.com/repos/spryker/installer/zipball/cd2743f1db0d7f0f9f646657477b322b5e0704f2",
+                "reference": "cd2743f1db0d7f0f9f646657477b322b5e0704f2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/installer-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/symfony": "^3.0.0"
@@ -33068,9 +33165,9 @@
             ],
             "description": "Installer module",
             "support": {
-                "source": "https://github.com/spryker/installer/tree/4.1.0"
+                "source": "https://github.com/spryker/installer/tree/4.2.0"
             },
-            "time": "2023-03-03T10:58:02+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/installer-extension",
@@ -33154,21 +33251,21 @@
         },
         {
             "name": "spryker/kernel",
-            "version": "3.73.0",
+            "version": "3.74.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/kernel.git",
-                "reference": "9f22c67cf2b53eb5a8f201a0742317eeadc33c60"
+                "reference": "326f7ff3f4b6af5a6fe37b7e6cb1d48d75056292"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/kernel/zipball/9f22c67cf2b53eb5a8f201a0742317eeadc33c60",
-                "reference": "9f22c67cf2b53eb5a8f201a0742317eeadc33c60",
+                "url": "https://api.github.com/repos/spryker/kernel/zipball/326f7ff3f4b6af5a6fe37b7e6cb1d48d75056292",
+                "reference": "326f7ff3f4b6af5a6fe37b7e6cb1d48d75056292",
                 "shasum": ""
             },
             "require": {
                 "everon/collection": "^1.0.0",
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/config": "^3.5.0",
                 "spryker/container": "^1.1.0",
                 "spryker/error-handler": "^2.2.0",
@@ -33209,9 +33306,9 @@
             ],
             "description": "Kernel module",
             "support": {
-                "source": "https://github.com/spryker/kernel/tree/3.73.0"
+                "source": "https://github.com/spryker/kernel/tree/3.74.0"
             },
-            "time": "2023-06-13T10:42:20+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/key-builder",
@@ -33295,16 +33392,16 @@
         },
         {
             "name": "spryker/locale",
-            "version": "4.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/locale.git",
-                "reference": "71be6de97df74807c0eeb2e848ec752366b246b5"
+                "reference": "d65201d202bb58790cd8872eae2d599040d14b45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/locale/zipball/71be6de97df74807c0eeb2e848ec752366b246b5",
-                "reference": "71be6de97df74807c0eeb2e848ec752366b246b5",
+                "url": "https://api.github.com/repos/spryker/locale/zipball/d65201d202bb58790cd8872eae2d599040d14b45",
+                "reference": "d65201d202bb58790cd8872eae2d599040d14b45",
                 "shasum": ""
             },
             "require": {
@@ -33317,7 +33414,8 @@
                 "spryker/propel-orm": "^1.8.0",
                 "spryker/store": "^1.19.0",
                 "spryker/store-extension": "^1.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/willdurand-negotiation": "^1.0.0",
                 "spryker/zed-request-extension": "^1.1.0"
             },
             "require-dev": {
@@ -33358,9 +33456,9 @@
             ],
             "description": "Locale module",
             "support": {
-                "source": "https://github.com/spryker/locale/tree/4.1.0"
+                "source": "https://github.com/spryker/locale/tree/4.2.0"
             },
-            "time": "2023-07-11T10:55:36+00:00"
+            "time": "2023-10-17T16:01:45+00:00"
         },
         {
             "name": "spryker/locale-data-import",
@@ -33508,20 +33606,20 @@
         },
         {
             "name": "spryker/log",
-            "version": "3.15.0",
+            "version": "3.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/log.git",
-                "reference": "ba336833734a71c5d99d0be2a517d8ba9fd66f29"
+                "reference": "c4f42e40cdd637746f30a6ec5342ac1ffbf0a9f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/log/zipball/ba336833734a71c5d99d0be2a517d8ba9fd66f29",
-                "reference": "ba336833734a71c5d99d0be2a517d8ba9fd66f29",
+                "url": "https://api.github.com/repos/spryker/log/zipball/c4f42e40cdd637746f30a6ec5342ac1ffbf0a9f5",
+                "reference": "c4f42e40cdd637746f30a6ec5342ac1ffbf0a9f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "psr/log": "^1.0.0",
                 "spryker/config": "^3.0.0",
                 "spryker/kernel": "^3.48.0",
@@ -33559,9 +33657,9 @@
             ],
             "description": "Log module",
             "support": {
-                "source": "https://github.com/spryker/log/tree/3.15.0"
+                "source": "https://github.com/spryker/log/tree/3.16.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/mail",
@@ -37682,30 +37780,30 @@
         },
         {
             "name": "spryker/message-broker",
-            "version": "1.7.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/message-broker.git",
-                "reference": "2a914fc4ab70ecbe0646b866929f058d35184f8d"
+                "reference": "505bccef1b489f2a19e7c920820ca74d49dab3d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/message-broker/zipball/2a914fc4ab70ecbe0646b866929f058d35184f8d",
-                "reference": "2a914fc4ab70ecbe0646b866929f058d35184f8d",
+                "url": "https://api.github.com/repos/spryker/message-broker/zipball/505bccef1b489f2a19e7c920820ca74d49dab3d8",
+                "reference": "505bccef1b489f2a19e7c920820ca74d49dab3d8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/log": "^3.0.0",
-                "spryker/message-broker-extension": "^1.1.0",
+                "spryker/message-broker-extension": "^1.2.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/symfony": "^3.10.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-encoding": "^1.0.0 || ^2.0.0"
             },
             "require-dev": {
-                "spryker-sdk/async-api": "^0.2.0",
+                "spryker-sdk/async-api": "^0.3.0",
                 "spryker/application": "*",
                 "spryker/code-sniffer": "*",
                 "spryker/console": "*",
@@ -37737,9 +37835,9 @@
             ],
             "description": "MessageBroker module",
             "support": {
-                "source": "https://github.com/spryker/message-broker/tree/1.7.0"
+                "source": "https://github.com/spryker/message-broker/tree/1.10.0"
             },
-            "time": "2023-06-22T09:38:01+00:00"
+            "time": "2023-12-07T09:15:27+00:00"
         },
         {
             "name": "spryker/message-broker-aws",
@@ -37803,16 +37901,16 @@
         },
         {
             "name": "spryker/message-broker-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/message-broker-extension.git",
-                "reference": "8360ac910ec5458e47ce4e3d6600073111d57298"
+                "reference": "c7fee41058388c635c07fd3787b451a2736340d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/message-broker-extension/zipball/8360ac910ec5458e47ce4e3d6600073111d57298",
-                "reference": "8360ac910ec5458e47ce4e3d6600073111d57298",
+                "url": "https://api.github.com/repos/spryker/message-broker-extension/zipball/c7fee41058388c635c07fd3787b451a2736340d1",
+                "reference": "c7fee41058388c635c07fd3787b451a2736340d1",
                 "shasum": ""
             },
             "require": {
@@ -37844,9 +37942,9 @@
             ],
             "description": "MessageBrokerExtension module",
             "support": {
-                "source": "https://github.com/spryker/message-broker-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/message-broker-extension/tree/1.2.0"
             },
-            "time": "2022-12-23T11:50:03+00:00"
+            "time": "2023-07-21T13:09:09+00:00"
         },
         {
             "name": "spryker/messenger",
@@ -37944,21 +38042,21 @@
         },
         {
             "name": "spryker/money",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/money.git",
-                "reference": "976e44e6b0cb7af9178ab40861b568fab4dc73da"
+                "reference": "e9d8c0e8359c457075c50c75bca929a155991e99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/money/zipball/976e44e6b0cb7af9178ab40861b568fab4dc73da",
-                "reference": "976e44e6b0cb7af9178ab40861b568fab4dc73da",
+                "url": "https://api.github.com/repos/spryker/money/zipball/e9d8c0e8359c457075c50c75bca929a155991e99",
+                "reference": "e9d8c0e8359c457075c50c75bca929a155991e99",
                 "shasum": ""
             },
             "require": {
                 "moneyphp/money": "^3.0.0",
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/currency": "^3.2.0 || ^4.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
@@ -38000,9 +38098,9 @@
             ],
             "description": "Money module",
             "support": {
-                "source": "https://github.com/spryker/money/tree/2.12.0"
+                "source": "https://github.com/spryker/money/tree/2.13.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/money-gui",
@@ -39766,20 +39864,20 @@
         },
         {
             "name": "spryker/oms",
-            "version": "11.26.5",
+            "version": "11.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/oms.git",
-                "reference": "7677ff2d756f73191c4b1df1fe2aed04146bd400"
+                "reference": "a8b5a3481a0ba5474e014d3d397eaee4410a7271"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/oms/zipball/7677ff2d756f73191c4b1df1fe2aed04146bd400",
-                "reference": "7677ff2d756f73191c4b1df1fe2aed04146bd400",
+                "url": "https://api.github.com/repos/spryker/oms/zipball/a8b5a3481a0ba5474e014d3d397eaee4410a7271",
+                "reference": "a8b5a3481a0ba5474e014d3d397eaee4410a7271",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/decimal-object": "^1.0.0",
                 "spryker/error-handler": "^2.1.0",
@@ -39832,9 +39930,9 @@
             ],
             "description": "Oms module",
             "support": {
-                "source": "https://github.com/spryker/oms/tree/11.26.5"
+                "source": "https://github.com/spryker/oms/tree/11.28.0"
             },
-            "time": "2023-06-16T09:24:47+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/oms-discount-connector",
@@ -42544,20 +42642,20 @@
         },
         {
             "name": "spryker/product",
-            "version": "6.36.3",
+            "version": "6.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product.git",
-                "reference": "a1c280f867e5e3f8844eb2e01d8dea9723fc8c01"
+                "reference": "59ba49bace444c1b565bbaee6af0ca9a5c5ef2d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product/zipball/a1c280f867e5e3f8844eb2e01d8dea9723fc8c01",
-                "reference": "a1c280f867e5e3f8844eb2e01d8dea9723fc8c01",
+                "url": "https://api.github.com/repos/spryker/product/zipball/59ba49bace444c1b565bbaee6af0ca9a5c5ef2d9",
+                "reference": "59ba49bace444c1b565bbaee6af0ca9a5c5ef2d9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/event": "^1.0.0 || ^2.3.0",
                 "spryker/kernel": "^3.34.0",
@@ -42603,9 +42701,9 @@
             ],
             "description": "Product module",
             "support": {
-                "source": "https://github.com/spryker/product/tree/6.36.3"
+                "source": "https://github.com/spryker/product/tree/6.38.0"
             },
-            "time": "2023-06-16T09:24:47+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/product-abstract-data-feed",
@@ -43872,20 +43970,20 @@
         },
         {
             "name": "spryker/product-category",
-            "version": "4.21.0",
+            "version": "4.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-category.git",
-                "reference": "7f0e199369cb871c5693df4d66be36886f4cf28a"
+                "reference": "06609089cbe5abe9187c78608097adfa58c768a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-category/zipball/7f0e199369cb871c5693df4d66be36886f4cf28a",
-                "reference": "7f0e199369cb871c5693df4d66be36886f4cf28a",
+                "url": "https://api.github.com/repos/spryker/product-category/zipball/06609089cbe5abe9187c78608097adfa58c768a0",
+                "reference": "06609089cbe5abe9187c78608097adfa58c768a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/category": "^3.3.0 || ^4.24.0 || ^5.11.0",
                 "spryker/category-extension": "^1.1.0",
@@ -43930,9 +44028,9 @@
             ],
             "description": "ProductCategory module",
             "support": {
-                "source": "https://github.com/spryker/product-category/tree/4.21.0"
+                "source": "https://github.com/spryker/product-category/tree/4.22.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/product-category-filter",
@@ -45754,16 +45852,16 @@
         },
         {
             "name": "spryker/product-image",
-            "version": "3.16.0",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-image.git",
-                "reference": "768d310f354c7b3230f85aa9814c325dbb759b7d"
+                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-image/zipball/768d310f354c7b3230f85aa9814c325dbb759b7d",
-                "reference": "768d310f354c7b3230f85aa9814c325dbb759b7d",
+                "url": "https://api.github.com/repos/spryker/product-image/zipball/ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
+                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
                 "shasum": ""
             },
             "require": {
@@ -45801,9 +45899,9 @@
             ],
             "description": "ProductImage module",
             "support": {
-                "source": "https://github.com/spryker/product-image/tree/3.16.0"
+                "source": "https://github.com/spryker/product-image/tree/3.17.0"
             },
-            "time": "2023-04-17T15:49:27+00:00"
+            "time": "2023-07-17T12:04:54+00:00"
         },
         {
             "name": "spryker/product-image-cart-connector",
@@ -48680,20 +48778,20 @@
         },
         {
             "name": "spryker/product-option",
-            "version": "8.15.2",
+            "version": "8.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-option.git",
-                "reference": "251fea2cef43316399f0c726cd0009dd3cbd1c90"
+                "reference": "c600a2fe6a16c7e030de5f5ffc237684bb85d886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-option/zipball/251fea2cef43316399f0c726cd0009dd3cbd1c90",
-                "reference": "251fea2cef43316399f0c726cd0009dd3cbd1c90",
+                "url": "https://api.github.com/repos/spryker/product-option/zipball/c600a2fe6a16c7e030de5f5ffc237684bb85d886",
+                "reference": "c600a2fe6a16c7e030de5f5ffc237684bb85d886",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation-extension": "^1.1.0",
                 "spryker/country": "^3.0.0 || ^4.0.0",
@@ -48763,9 +48861,9 @@
             ],
             "description": "ProductOption module",
             "support": {
-                "source": "https://github.com/spryker/product-option/tree/8.15.2"
+                "source": "https://github.com/spryker/product-option/tree/8.16.0"
             },
-            "time": "2023-05-05T18:20:59+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/product-option-cart-connector",
@@ -50275,24 +50373,24 @@
         },
         {
             "name": "spryker/product-search",
-            "version": "5.19.0",
+            "version": "5.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-search.git",
-                "reference": "0eef6daa5503d6375585b0304d35c9819a48e0ed"
+                "reference": "a1ae429ba1f20aced61f157972db2b4657a20849"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-search/zipball/0eef6daa5503d6375585b0304d35c9819a48e0ed",
-                "reference": "0eef6daa5503d6375585b0304d35c9819a48e0ed",
+                "url": "https://api.github.com/repos/spryker/product-search/zipball/a1ae429ba1f20aced61f157972db2b4657a20849",
+                "reference": "a1ae429ba1f20aced61f157972db2b4657a20849",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/collector": "^5.1.1 || ^6.0.0",
                 "spryker/event": "^2.1.0",
-                "spryker/glossary": "^3.0.0",
+                "spryker/glossary": "^3.16.0",
                 "spryker/gui": "^3.33.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.1.0",
@@ -50306,7 +50404,7 @@
                 "spryker/store": "^1.4.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-data-reader": "^1.0.0"
             },
             "require-dev": {
@@ -50336,9 +50434,9 @@
             ],
             "description": "ProductSearch module",
             "support": {
-                "source": "https://github.com/spryker/product-search/tree/5.19.0"
+                "source": "https://github.com/spryker/product-search/tree/5.21.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-27T15:01:56+00:00"
         },
         {
             "name": "spryker/product-search-config-storage",
@@ -50999,20 +51097,20 @@
         },
         {
             "name": "spryker/propel",
-            "version": "3.38.0",
+            "version": "3.39.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/propel.git",
-                "reference": "26b4e6b523f8411b86fb59e02f80016111e63529"
+                "reference": "7fad9a13c46b04fcb8ae7b5f36f25da1ec7bb585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/propel/zipball/26b4e6b523f8411b86fb59e02f80016111e63529",
-                "reference": "26b4e6b523f8411b86fb59e02f80016111e63529",
+                "url": "https://api.github.com/repos/spryker/propel/zipball/7fad9a13c46b04fcb8ae7b5f36f25da1ec7bb585",
+                "reference": "7fad9a13c46b04fcb8ae7b5f36f25da1ec7bb585",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/config": "^3.0.0",
                 "spryker/health-check-extension": "^1.0.0",
@@ -51055,9 +51153,9 @@
             ],
             "description": "Propel module",
             "support": {
-                "source": "https://github.com/spryker/propel/tree/3.38.0"
+                "source": "https://github.com/spryker/propel/tree/3.39.0"
             },
-            "time": "2023-04-18T12:08:37+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/propel-orm",
@@ -51502,20 +51600,20 @@
         },
         {
             "name": "spryker/queue",
-            "version": "1.9.3",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/queue.git",
-                "reference": "ae7fe9452f5c2d65e7e3652f2469eed1c0e4865e"
+                "reference": "9dad70c821ee6bab666aa1ab42e81d2f4d57af1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/queue/zipball/ae7fe9452f5c2d65e7e3652f2469eed1c0e4865e",
-                "reference": "ae7fe9452f5c2d65e7e3652f2469eed1c0e4865e",
+                "url": "https://api.github.com/repos/spryker/queue/zipball/9dad70c821ee6bab666aa1ab42e81d2f4d57af1a",
+                "reference": "9dad70c821ee6bab666aa1ab42e81d2f4d57af1a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/gui": "^3.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -51553,9 +51651,9 @@
             ],
             "description": "Queue module",
             "support": {
-                "source": "https://github.com/spryker/queue/tree/1.9.3"
+                "source": "https://github.com/spryker/queue/tree/1.10.0"
             },
-            "time": "2022-11-11T07:06:41+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/quick-order",
@@ -51647,20 +51745,20 @@
         },
         {
             "name": "spryker/quote",
-            "version": "2.18.0",
+            "version": "2.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/quote.git",
-                "reference": "e577815ae7bbe6e43f81fd657b3af92a19d88e2e"
+                "reference": "c75e2e8ea9739488b528f695b55e1f0568b0588a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/quote/zipball/e577815ae7bbe6e43f81fd657b3af92a19d88e2e",
-                "reference": "e577815ae7bbe6e43f81fd657b3af92a19d88e2e",
+                "url": "https://api.github.com/repos/spryker/quote/zipball/c75e2e8ea9739488b528f695b55e1f0568b0588a",
+                "reference": "c75e2e8ea9739488b528f695b55e1f0568b0588a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/agent-extension": "^1.0.0",
                 "spryker/comment-extension": "^1.0.0",
                 "spryker/currency": "^3.4.0 || ^4.0.0",
@@ -51700,9 +51798,9 @@
             ],
             "description": "Quote module",
             "support": {
-                "source": "https://github.com/spryker/quote/tree/2.18.0"
+                "source": "https://github.com/spryker/quote/tree/2.19.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-10T12:45:47+00:00"
         },
         {
             "name": "spryker/quote-approval",
@@ -52269,20 +52367,20 @@
         },
         {
             "name": "spryker/redis",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/redis.git",
-                "reference": "8c560832ee4b87714c8e420e3ce23f489a762ab1"
+                "reference": "78c1774c393a601194d3be1edcd287e4b1f74df6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/redis/zipball/8c560832ee4b87714c8e420e3ce23f489a762ab1",
-                "reference": "8c560832ee4b87714c8e420e3ce23f489a762ab1",
+                "url": "https://api.github.com/repos/spryker/redis/zipball/78c1774c393a601194d3be1edcd287e4b1f74df6",
+                "reference": "78c1774c393a601194d3be1edcd287e4b1f74df6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
+                "php": ">=8.1",
                 "predis/predis": "^1.1.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/symfony": "^3.0.0",
@@ -52315,26 +52413,26 @@
             ],
             "description": "Redis module",
             "support": {
-                "source": "https://github.com/spryker/redis/tree/2.6.1"
+                "source": "https://github.com/spryker/redis/tree/2.7.0"
             },
-            "time": "2021-01-28T14:19:38+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/refund",
-            "version": "5.7.2",
+            "version": "5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/refund.git",
-                "reference": "108fcc579a30134a38f53ae19cbe1cea6ec3f87b"
+                "reference": "558f980c3eaf19d869a1e1468f38a548decaddd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/refund/zipball/108fcc579a30134a38f53ae19cbe1cea6ec3f87b",
-                "reference": "108fcc579a30134a38f53ae19cbe1cea6ec3f87b",
+                "url": "https://api.github.com/repos/spryker/refund/zipball/558f980c3eaf19d869a1e1468f38a548decaddd5",
+                "reference": "558f980c3eaf19d869a1e1468f38a548decaddd5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation": "^4.0.0",
                 "spryker/gui": "^3.0.0",
@@ -52376,9 +52474,9 @@
             ],
             "description": "Refund module",
             "support": {
-                "source": "https://github.com/spryker/refund/tree/5.7.2"
+                "source": "https://github.com/spryker/refund/tree/5.8.0"
             },
-            "time": "2023-06-06T15:14:45+00:00"
+            "time": "2023-12-07T16:17:29+00:00"
         },
         {
             "name": "spryker/refund-extension",
@@ -52614,20 +52712,20 @@
         },
         {
             "name": "spryker/router",
-            "version": "1.15.1",
+            "version": "1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/router.git",
-                "reference": "0021d531a083230819cd72d0f693727b6f0630f5"
+                "reference": "d31caaad15db133fac32200280622ddd423d2b74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/router/zipball/0021d531a083230819cd72d0f693727b6f0630f5",
-                "reference": "0021d531a083230819cd72d0f693727b6f0630f5",
+                "url": "https://api.github.com/repos/spryker/router/zipball/d31caaad15db133fac32200280622ddd423d2b74",
+                "reference": "d31caaad15db133fac32200280622ddd423d2b74",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/container": "^1.1.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
@@ -52667,9 +52765,9 @@
             ],
             "description": "Router module",
             "support": {
-                "source": "https://github.com/spryker/router/tree/1.15.1"
+                "source": "https://github.com/spryker/router/tree/1.18.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/router-extension",
@@ -52721,20 +52819,20 @@
         },
         {
             "name": "spryker/sales",
-            "version": "11.40.5",
+            "version": "11.44.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales.git",
-                "reference": "50e134623b85dfe29e5292aa6eb5a42ee259deb9"
+                "reference": "f4e68725ae5437d112dec237417f17bd264cb575"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales/zipball/50e134623b85dfe29e5292aa6eb5a42ee259deb9",
-                "reference": "50e134623b85dfe29e5292aa6eb5a42ee259deb9",
+                "url": "https://api.github.com/repos/spryker/sales/zipball/f4e68725ae5437d112dec237417f17bd264cb575",
+                "reference": "f4e68725ae5437d112dec237417f17bd264cb575",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation": "^4.0.0",
                 "spryker/checkout-extension": "^1.2.0",
@@ -52747,7 +52845,7 @@
                 "spryker/oms": "^10.3.0 || ^11.0.0",
                 "spryker/propel": "^3.0.0",
                 "spryker/propel-orm": "^1.16.0",
-                "spryker/sales-extension": "^1.9.0",
+                "spryker/sales-extension": "^1.10.0",
                 "spryker/sales-split": "^3.0.0 || ^5.0.0",
                 "spryker/sequence-number": "^3.0.0",
                 "spryker/store": "^1.0.0",
@@ -52796,9 +52894,9 @@
             ],
             "description": "Sales module",
             "support": {
-                "source": "https://github.com/spryker/sales/tree/11.40.5"
+                "source": "https://github.com/spryker/sales/tree/11.44.0"
             },
-            "time": "2023-07-07T11:59:09+00:00"
+            "time": "2023-12-11T16:30:30+00:00"
         },
         {
             "name": "spryker/sales-configurable-bundle",
@@ -52911,20 +53009,20 @@
         },
         {
             "name": "spryker/sales-extension",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales-extension.git",
-                "reference": "3e8555b4cb07dbe0543aae039a2f96b3a770fcd4"
+                "reference": "c3ef08c36bd2ae72f2908611ee63a73f3f112fca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales-extension/zipball/3e8555b4cb07dbe0543aae039a2f96b3a770fcd4",
-                "reference": "3e8555b4cb07dbe0543aae039a2f96b3a770fcd4",
+                "url": "https://api.github.com/repos/spryker/sales-extension/zipball/c3ef08c36bd2ae72f2908611ee63a73f3f112fca",
+                "reference": "c3ef08c36bd2ae72f2908611ee63a73f3f112fca",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -52946,9 +53044,9 @@
             ],
             "description": "SalesExtension module",
             "support": {
-                "source": "https://github.com/spryker/sales-extension/tree/1.9.0"
+                "source": "https://github.com/spryker/sales-extension/tree/1.10.0"
             },
-            "time": "2021-06-24T13:01:59+00:00"
+            "time": "2023-12-11T16:30:30+00:00"
         },
         {
             "name": "spryker/sales-invoice",
@@ -54422,20 +54520,20 @@
         },
         {
             "name": "spryker/sales-split",
-            "version": "5.1.1",
+            "version": "5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales-split.git",
-                "reference": "a937728a082cd4b4f8827a27a7a80d705df5b1f4"
+                "reference": "75f5a6cf3af2be8a22b0d1188e9980197319ad59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales-split/zipball/a937728a082cd4b4f8827a27a7a80d705df5b1f4",
-                "reference": "a937728a082cd4b4f8827a27a7a80d705df5b1f4",
+                "url": "https://api.github.com/repos/spryker/sales-split/zipball/75f5a6cf3af2be8a22b0d1188e9980197319ad59",
+                "reference": "75f5a6cf3af2be8a22b0d1188e9980197319ad59",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/sales": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^10.0.0 || ^11.0.0",
@@ -54463,9 +54561,9 @@
             ],
             "description": "SalesSplit module",
             "support": {
-                "source": "https://github.com/spryker/sales-split/tree/5.1.1"
+                "source": "https://github.com/spryker/sales-split/tree/5.2.0"
             },
-            "time": "2020-05-29T13:08:37+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/sales-statistics",
@@ -54670,20 +54768,20 @@
         },
         {
             "name": "spryker/search",
-            "version": "8.20.0",
+            "version": "8.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search.git",
-                "reference": "7d611a3672526f4341eb15db73f5f84d7a85fe50"
+                "reference": "a59961ecc55f8b2f87dc3ad44e50cab992096bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search/zipball/7d611a3672526f4341eb15db73f5f84d7a85fe50",
-                "reference": "7d611a3672526f4341eb15db73f5f84d7a85fe50",
+                "url": "https://api.github.com/repos/spryker/search/zipball/a59961ecc55f8b2f87dc3ad44e50cab992096bd1",
+                "reference": "a59961ecc55f8b2f87dc3ad44e50cab992096bd1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/config": "^3.0.0",
                 "spryker/elastica": "^4.0.0 || ^5.0.0 || ^6.0.0",
                 "spryker/gui": "^3.0.0",
@@ -54732,9 +54830,9 @@
             ],
             "description": "Search module",
             "support": {
-                "source": "https://github.com/spryker/search/tree/8.20.0"
+                "source": "https://github.com/spryker/search/tree/8.22.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/search-elasticsearch",
@@ -54853,16 +54951,16 @@
         },
         {
             "name": "spryker/search-extension",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search-extension.git",
-                "reference": "deed18da2ba98f335272ffc4f78eb56851ede2ba"
+                "reference": "149f7e2e993067718af9170eabc45fb58a255fda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search-extension/zipball/deed18da2ba98f335272ffc4f78eb56851ede2ba",
-                "reference": "deed18da2ba98f335272ffc4f78eb56851ede2ba",
+                "url": "https://api.github.com/repos/spryker/search-extension/zipball/149f7e2e993067718af9170eabc45fb58a255fda",
+                "reference": "149f7e2e993067718af9170eabc45fb58a255fda",
                 "shasum": ""
             },
             "require": {
@@ -54893,9 +54991,9 @@
             ],
             "description": "SearchExtension module",
             "support": {
-                "source": "https://github.com/spryker/search-extension/tree/1.2.0"
+                "source": "https://github.com/spryker/search-extension/tree/1.3.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-09-11T11:36:57+00:00"
         },
         {
             "name": "spryker/search-http",
@@ -56048,20 +56146,20 @@
         },
         {
             "name": "spryker/session",
-            "version": "4.15.1",
+            "version": "4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/session.git",
-                "reference": "f62376d44c4b7044cd9dceda5f223df6286476f4"
+                "reference": "8b0943ff4b7c02d2e69d5b7ccf4f6f73563b0248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/session/zipball/f62376d44c4b7044cd9dceda5f223df6286476f4",
-                "reference": "f62376d44c4b7044cd9dceda5f223df6286476f4",
+                "url": "https://api.github.com/repos/spryker/session/zipball/8b0943ff4b7c02d2e69d5b7ccf4f6f73563b0248",
+                "reference": "8b0943ff4b7c02d2e69d5b7ccf4f6f73563b0248",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/config": "^3.0.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
@@ -56108,9 +56206,9 @@
             ],
             "description": "Session module",
             "support": {
-                "source": "https://github.com/spryker/session/tree/4.15.1"
+                "source": "https://github.com/spryker/session/tree/4.16.0"
             },
-            "time": "2023-02-24T06:44:56+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/session-customer-validation-extension",
@@ -56758,22 +56856,22 @@
         },
         {
             "name": "spryker/shipment",
-            "version": "8.15.2",
+            "version": "8.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment.git",
-                "reference": "f36ddcbe915591f59a041efac02d12842b7a974e"
+                "reference": "4f575b31cf7bf500750e71e3fda53a0663644088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment/zipball/f36ddcbe915591f59a041efac02d12842b7a974e",
-                "reference": "f36ddcbe915591f59a041efac02d12842b7a974e",
+                "url": "https://api.github.com/repos/spryker/shipment/zipball/4f575b31cf7bf500750e71e3fda53a0663644088",
+                "reference": "4f575b31cf7bf500750e71e3fda53a0663644088",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
-                "spryker/calculation": "^4.8.0",
+                "spryker/calculation": "^4.9.0",
                 "spryker/calculation-extension": "^1.0.0",
                 "spryker/country": "^3.0.0 || ^4.0.0",
                 "spryker/currency": "^3.1.0 || ^4.0.0",
@@ -56786,7 +56884,7 @@
                 "spryker/sales": "^11.25.0",
                 "spryker/sales-extension": "^1.6.0",
                 "spryker/session": "^3.0.0 || ^4.0.0",
-                "spryker/shipment-extension": "^1.1.0",
+                "spryker/shipment-extension": "^1.2.0",
                 "spryker/store": "^1.4.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/tax": "^5.0.0",
@@ -56824,9 +56922,9 @@
             ],
             "description": "Shipment module",
             "support": {
-                "source": "https://github.com/spryker/shipment/tree/8.15.2"
+                "source": "https://github.com/spryker/shipment/tree/8.19.0"
             },
-            "time": "2023-06-06T15:14:45+00:00"
+            "time": "2023-11-24T10:18:08+00:00"
         },
         {
             "name": "spryker/shipment-cart-connector",
@@ -57030,20 +57128,21 @@
         },
         {
             "name": "spryker/shipment-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment-extension.git",
-                "reference": "617c4a5fc41fc141f368e7133aab7e0cc8464b4a"
+                "reference": "60944ddd7eb0cb42da0e37ff3953590353434ba3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment-extension/zipball/617c4a5fc41fc141f368e7133aab7e0cc8464b4a",
-                "reference": "617c4a5fc41fc141f368e7133aab7e0cc8464b4a",
+                "url": "https://api.github.com/repos/spryker/shipment-extension/zipball/60944ddd7eb0cb42da0e37ff3953590353434ba3",
+                "reference": "60944ddd7eb0cb42da0e37ff3953590353434ba3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=8.0",
+                "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -57065,9 +57164,9 @@
             ],
             "description": "ShipmentExtension module",
             "support": {
-                "source": "https://github.com/spryker/shipment-extension/tree/master"
+                "source": "https://github.com/spryker/shipment-extension/tree/1.2.0"
             },
-            "time": "2020-03-11T14:56:31+00:00"
+            "time": "2023-08-01T09:25:56+00:00"
         },
         {
             "name": "spryker/shipment-gui",
@@ -58046,20 +58145,20 @@
         },
         {
             "name": "spryker/step-engine",
-            "version": "3.4.3",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/step-engine.git",
-                "reference": "6d0846cad06bc1410bd527a5d5fe3280bb3c100b"
+                "reference": "8c1b0859a82d634451acc69ef50fa56e2f50ea15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/step-engine/zipball/6d0846cad06bc1410bd527a5d5fe3280bb3c100b",
-                "reference": "6d0846cad06bc1410bd527a5d5fe3280bb3c100b",
+                "url": "https://api.github.com/repos/spryker/step-engine/zipball/8c1b0859a82d634451acc69ef50fa56e2f50ea15",
+                "reference": "8c1b0859a82d634451acc69ef50fa56e2f50ea15",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/step-engine-extension": "^1.0.0",
                 "spryker/symfony": "^3.0.0"
@@ -58089,9 +58188,9 @@
             ],
             "description": "StepEngine module",
             "support": {
-                "source": "https://github.com/spryker/step-engine/tree/3.4.3"
+                "source": "https://github.com/spryker/step-engine/tree/3.5.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/step-engine-extension",
@@ -58140,16 +58239,16 @@
         },
         {
             "name": "spryker/stock",
-            "version": "8.8.2",
+            "version": "8.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/stock.git",
-                "reference": "7255d93e4ec1f640bd3d3d8f16e7baaf02c236f8"
+                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/stock/zipball/7255d93e4ec1f640bd3d3d8f16e7baaf02c236f8",
-                "reference": "7255d93e4ec1f640bd3d3d8f16e7baaf02c236f8",
+                "url": "https://api.github.com/repos/spryker/stock/zipball/5261ab0f27009e6e3bae8d9edc44b83f52353138",
+                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138",
                 "shasum": ""
             },
             "require": {
@@ -58188,9 +58287,9 @@
             ],
             "description": "Stock module",
             "support": {
-                "source": "https://github.com/spryker/stock/tree/8.8.2"
+                "source": "https://github.com/spryker/stock/tree/8.8.3"
             },
-            "time": "2023-05-05T18:20:59+00:00"
+            "time": "2023-07-25T12:51:44+00:00"
         },
         {
             "name": "spryker/stock-address",
@@ -58426,20 +58525,20 @@
         },
         {
             "name": "spryker/storage",
-            "version": "3.20.1",
+            "version": "3.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/storage.git",
-                "reference": "e18aa318532a53831a66ff406ba4529119091b01"
+                "reference": "31bfe245ad7d7c9b439cd9efdb3f06fb9536ec60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/storage/zipball/e18aa318532a53831a66ff406ba4529119091b01",
-                "reference": "e18aa318532a53831a66ff406ba4529119091b01",
+                "url": "https://api.github.com/repos/spryker/storage/zipball/31bfe245ad7d7c9b439cd9efdb3f06fb9536ec60",
+                "reference": "31bfe245ad7d7c9b439cd9efdb3f06fb9536ec60",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/config": "^3.0.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/gui": "^3.0.0",
@@ -58486,9 +58585,9 @@
             ],
             "description": "Storage module",
             "support": {
-                "source": "https://github.com/spryker/storage/tree/3.20.1"
+                "source": "https://github.com/spryker/storage/tree/3.22.0"
             },
-            "time": "2023-07-12T09:45:07+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/storage-database",
@@ -58723,20 +58822,20 @@
         },
         {
             "name": "spryker/store",
-            "version": "1.20.0",
+            "version": "1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/store.git",
-                "reference": "a9996e7c6f5c6ee5b63382bbe5d26de91a6ccb8c"
+                "reference": "e43d709512f8dfc705205c7bfff918d46166e8ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/store/zipball/a9996e7c6f5c6ee5b63382bbe5d26de91a6ccb8c",
-                "reference": "a9996e7c6f5c6ee5b63382bbe5d26de91a6ccb8c",
+                "url": "https://api.github.com/repos/spryker/store/zipball/e43d709512f8dfc705205c7bfff918d46166e8ed",
+                "reference": "e43d709512f8dfc705205c7bfff918d46166e8ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
@@ -58748,6 +58847,7 @@
                 "spryker/store-extension": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
+                "spryker/zed-request": "^3.3.0",
                 "spryker/zed-request-extension": "^1.1.0"
             },
             "require-dev": {
@@ -58781,9 +58881,9 @@
             ],
             "description": "Store module",
             "support": {
-                "source": "https://github.com/spryker/store/tree/1.20.0"
+                "source": "https://github.com/spryker/store/tree/1.24.0"
             },
-            "time": "2023-05-22T19:10:17+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/store-context-gui",
@@ -59133,20 +59233,20 @@
         },
         {
             "name": "spryker/symfony",
-            "version": "3.12.0",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/symfony.git",
-                "reference": "63730730f5f3a9fdaf8fcb46c3dc9272fff3226c"
+                "reference": "5310f7b7af7de82957a65c637d872e5542e5e702"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/symfony/zipball/63730730f5f3a9fdaf8fcb46c3dc9272fff3226c",
-                "reference": "63730730f5f3a9fdaf8fcb46c3dc9272fff3226c",
+                "url": "https://api.github.com/repos/spryker/symfony/zipball/5310f7b7af7de82957a65c637d872e5542e5e702",
+                "reference": "5310f7b7af7de82957a65c637d872e5542e5e702",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "symfony-cmf/routing": "^2.3.3 || ^3.0.0",
                 "symfony/config": "^5.0.9 || ^6.0.0",
                 "symfony/console": "^5.3.0 || ^6.0.0",
@@ -59169,12 +59269,12 @@
                 "symfony/security-core": "^5.4.21",
                 "symfony/security-csrf": "^5.3.0 || ^6.0.0",
                 "symfony/security-guard": "^5.4.21",
-                "symfony/security-http": "^5.4.21",
+                "symfony/security-http": "^5.4.31",
                 "symfony/serializer": "^5.0.9 || ^6.0.0",
                 "symfony/stopwatch": "^5.0.9 || ^6.0.0",
                 "symfony/translation": "^5.0.9 || ^6.0.0",
                 "symfony/translation-contracts": "^2.1.2 || ^3.0.0",
-                "symfony/twig-bridge": "^5.0.9 || ^6.0.0",
+                "symfony/twig-bridge": "^5.4.31 || ^6.3.8",
                 "symfony/validator": "^5.2.0 || ^6.0.0",
                 "symfony/yaml": "^5.1.10  || ^6.0.0"
             },
@@ -59200,9 +59300,9 @@
             ],
             "description": "Symfony module",
             "support": {
-                "source": "https://github.com/spryker/symfony/tree/3.12.0"
+                "source": "https://github.com/spryker/symfony/tree/3.14.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-13T12:52:16+00:00"
         },
         {
             "name": "spryker/symfony-mailer",
@@ -59437,20 +59537,20 @@
         },
         {
             "name": "spryker/tax",
-            "version": "5.14.0",
+            "version": "5.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/tax.git",
-                "reference": "391a9fb49a66a2c284ce0e00f914f45c6539e83f"
+                "reference": "114523d37cca93821711d4ddd9700ee338a111c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/tax/zipball/391a9fb49a66a2c284ce0e00f914f45c6539e83f",
-                "reference": "391a9fb49a66a2c284ce0e00f914f45c6539e83f",
+                "url": "https://api.github.com/repos/spryker/tax/zipball/114523d37cca93821711d4ddd9700ee338a111c8",
+                "reference": "114523d37cca93821711d4ddd9700ee338a111c8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation": "^4.0.0",
                 "spryker/country": "^3.0.0 || ^4.0.0",
@@ -59495,9 +59595,9 @@
             ],
             "description": "Tax module",
             "support": {
-                "source": "https://github.com/spryker/tax/tree/5.14.0"
+                "source": "https://github.com/spryker/tax/tree/5.15.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/tax-merchant-portal-gui",
@@ -59768,20 +59868,20 @@
         },
         {
             "name": "spryker/touch",
-            "version": "4.6.0",
+            "version": "4.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/touch.git",
-                "reference": "83fdd4458fbd9cbfe66053d51f535b5446602fdf"
+                "reference": "93f921f5acbe1651edcc4e7cff6e93f23febe78f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/touch/zipball/83fdd4458fbd9cbfe66053d51f535b5446602fdf",
-                "reference": "83fdd4458fbd9cbfe66053d51f535b5446602fdf",
+                "url": "https://api.github.com/repos/spryker/touch/zipball/93f921f5acbe1651edcc4e7cff6e93f23febe78f",
+                "reference": "93f921f5acbe1651edcc4e7cff6e93f23febe78f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -59812,26 +59912,26 @@
             ],
             "description": "Touch module",
             "support": {
-                "source": "https://github.com/spryker/touch/tree/4.6.0"
+                "source": "https://github.com/spryker/touch/tree/4.7.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/transfer",
-            "version": "3.33.1",
+            "version": "3.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/transfer.git",
-                "reference": "45e2053b1da55df5bd0bd3b94b5df6e16b2d2d75"
+                "reference": "539b53f9da85ccdfeb17f64c18c0c2ba3eac2e79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/transfer/zipball/45e2053b1da55df5bd0bd3b94b5df6e16b2d2d75",
-                "reference": "45e2053b1da55df5bd0bd3b94b5df6e16b2d2d75",
+                "url": "https://api.github.com/repos/spryker/transfer/zipball/539b53f9da85ccdfeb17f64c18c0c2ba3eac2e79",
+                "reference": "539b53f9da85ccdfeb17f64c18c0c2ba3eac2e79",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/decimal-object": "^1.0.0",
                 "spryker/kernel": "^3.59.0",
                 "spryker/laminas": "^1.0.0",
@@ -59863,26 +59963,26 @@
             ],
             "description": "Transfer module",
             "support": {
-                "source": "https://github.com/spryker/transfer/tree/3.33.1"
+                "source": "https://github.com/spryker/transfer/tree/3.35.0"
             },
-            "time": "2022-11-11T07:06:41+00:00"
+            "time": "2023-11-20T09:35:42+00:00"
         },
         {
             "name": "spryker/translator",
-            "version": "1.11.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/translator.git",
-                "reference": "0ab70852c213081b053bdf42914cf1eaebaa13ac"
+                "reference": "fd1d6dff2300d5bd69fd0d3f128ae8c0992b0769"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/translator/zipball/0ab70852c213081b053bdf42914cf1eaebaa13ac",
-                "reference": "0ab70852c213081b053bdf42914cf1eaebaa13ac",
+                "url": "https://api.github.com/repos/spryker/translator/zipball/fd1d6dff2300d5bd69fd0d3f128ae8c0992b0769",
+                "reference": "fd1d6dff2300d5bd69fd0d3f128ae8c0992b0769",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/glossary-storage": "^1.0.0",
                 "spryker/kernel": "^3.52.0",
@@ -59899,6 +59999,8 @@
                 "spryker/container": "*",
                 "spryker/installer": "*",
                 "spryker/silex": "^2.2.0",
+                "spryker/storage": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -59922,9 +60024,9 @@
             ],
             "description": "Translator module",
             "support": {
-                "source": "https://github.com/spryker/translator/tree/1.11.0"
+                "source": "https://github.com/spryker/translator/tree/1.13.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-29T15:41:47+00:00"
         },
         {
             "name": "spryker/translator-extension",
@@ -59973,20 +60075,20 @@
         },
         {
             "name": "spryker/twig",
-            "version": "3.18.1",
+            "version": "3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/twig.git",
-                "reference": "07aa6395bd84fd14567c15a3f8c77a55bff0268a"
+                "reference": "edb5f3254ec226949b7346d243818053af6d7cdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/twig/zipball/07aa6395bd84fd14567c15a3f8c77a55bff0268a",
-                "reference": "07aa6395bd84fd14567c15a3f8c77a55bff0268a",
+                "url": "https://api.github.com/repos/spryker/twig/zipball/edb5f3254ec226949b7346d243818053af6d7cdc",
+                "reference": "edb5f3254ec226949b7346d243818053af6d7cdc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/container": "^1.1.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
@@ -60027,9 +60129,9 @@
             ],
             "description": "Twig module",
             "support": {
-                "source": "https://github.com/spryker/twig/tree/3.18.1"
+                "source": "https://github.com/spryker/twig/tree/3.19.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/twig-extension",
@@ -60340,20 +60442,20 @@
         },
         {
             "name": "spryker/user",
-            "version": "3.18.0",
+            "version": "3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user.git",
-                "reference": "f088b1f83625ba4fe6610d28e220ac2e7de2f788"
+                "reference": "a9e2d9f5f30a193da6f2b485e0a95c143125db23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user/zipball/f088b1f83625ba4fe6610d28e220ac2e7de2f788",
-                "reference": "f088b1f83625ba4fe6610d28e220ac2e7de2f788",
+                "url": "https://api.github.com/repos/spryker/user/zipball/a9e2d9f5f30a193da6f2b485e0a95c143125db23",
+                "reference": "a9e2d9f5f30a193da6f2b485e0a95c143125db23",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/gui": "^3.33.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -60407,9 +60509,9 @@
             ],
             "description": "User module",
             "support": {
-                "source": "https://github.com/spryker/user/tree/3.18.0"
+                "source": "https://github.com/spryker/user/tree/3.19.0"
             },
-            "time": "2023-04-17T15:49:27+00:00"
+            "time": "2023-11-02T20:09:27+00:00"
         },
         {
             "name": "spryker/user-extension",
@@ -60887,16 +60989,16 @@
         },
         {
             "name": "spryker/util-date-time",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/util-date-time.git",
-                "reference": "1dc77bf90621976dfb0858f1baf420459ccbfac1"
+                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/1dc77bf90621976dfb0858f1baf420459ccbfac1",
-                "reference": "1dc77bf90621976dfb0858f1baf420459ccbfac1",
+                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/01a1c0ca748c9d04faaa2dc404a2232132157962",
+                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962",
                 "shasum": ""
             },
             "require": {
@@ -60932,9 +61034,9 @@
             ],
             "description": "UtilDateTime module",
             "support": {
-                "source": "https://github.com/spryker/util-date-time/tree/1.4.0"
+                "source": "https://github.com/spryker/util-date-time/tree/1.4.1"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-07-27T15:38:05+00:00"
         },
         {
             "name": "spryker/util-encoding",
@@ -61331,20 +61433,20 @@
         },
         {
             "name": "spryker/util-text",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/util-text.git",
-                "reference": "715d1cb04b5222445f331564faff7dd934a71166"
+                "reference": "9d43926ccbbe4b6fdaf050c7a70a0cac2708382f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/util-text/zipball/715d1cb04b5222445f331564faff7dd934a71166",
-                "reference": "715d1cb04b5222445f331564faff7dd934a71166",
+                "url": "https://api.github.com/repos/spryker/util-text/zipball/9d43926ccbbe4b6fdaf050c7a70a0cac2708382f",
+                "reference": "9d43926ccbbe4b6fdaf050c7a70a0cac2708382f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/kernel": "^3.30.0"
             },
             "require-dev": {
@@ -61370,9 +61472,9 @@
             ],
             "description": "UtilText module",
             "support": {
-                "source": "https://github.com/spryker/util-text/tree/1.5.1"
+                "source": "https://github.com/spryker/util-text/tree/1.6.0"
             },
-            "time": "2022-12-01T11:40:47+00:00"
+            "time": "2023-12-06T14:05:47+00:00"
         },
         {
             "name": "spryker/util-uuid-generator",
@@ -61884,6 +61986,40 @@
             "time": "2021-07-07T15:14:17+00:00"
         },
         {
+            "name": "spryker/willdurand-negotiation",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/willdurand-negotiation.git",
+                "reference": "d94edafb762e7d1b65c140c8df62aadece12eb8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/willdurand-negotiation/zipball/d94edafb762e7d1b65c140c8df62aadece12eb8b",
+                "reference": "d94edafb762e7d1b65c140c8df62aadece12eb8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "willdurand/negotiation": "^2.3.0 || ^3.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "WilldurandNegotiation module",
+            "support": {
+                "source": "https://github.com/spryker/willdurand-negotiation/tree/1.0.0"
+            },
+            "time": "2023-10-17T16:01:45+00:00"
+        },
+        {
             "name": "spryker/wishlist-extension",
             "version": "1.3.0",
             "source": {
@@ -62071,16 +62207,16 @@
         },
         {
             "name": "spryker/zed-request",
-            "version": "3.19.0",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-request.git",
-                "reference": "bcc59ab5bd55b3a98d4670b873c2c8f8a4c66446"
+                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-request/zipball/bcc59ab5bd55b3a98d4670b873c2c8f8a4c66446",
-                "reference": "bcc59ab5bd55b3a98d4670b873c2c8f8a4c66446",
+                "url": "https://api.github.com/repos/spryker/zed-request/zipball/b06b5e843f8b3406436b0567dc6dd6581725fa1a",
+                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a",
                 "shasum": ""
             },
             "require": {
@@ -62136,9 +62272,9 @@
             ],
             "description": "ZedRequest module",
             "support": {
-                "source": "https://github.com/spryker/zed-request/tree/3.19.0"
+                "source": "https://github.com/spryker/zed-request/tree/3.20.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-10-19T09:26:16+00:00"
         },
         {
             "name": "spryker/zed-request-extension",
@@ -62499,25 +62635,25 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "81ca309f056e836480928b20280ec52ce8369bb3"
+                "reference": "ac2d25f97b17eec6e19760b6b9962a4f7c44356a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/81ca309f056e836480928b20280ec52ce8369bb3",
-                "reference": "81ca309f056e836480928b20280ec52ce8369bb3",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/ac2d25f97b17eec6e19760b6b9962a4f7c44356a",
+                "reference": "ac2d25f97b17eec6e19760b6b9962a4f7c44356a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/cache": "^2.0|^3.0",
                 "psr/log": "^1.1|^2|^3",
-                "symfony/cache-contracts": "^1.1.7|^2|^3",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/var-exporter": "^5.4|^6.0"
+                "symfony/cache-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/var-exporter": "^6.3.6|^7.0"
             },
             "conflict": {
                 "doctrine/dbal": "<2.13.1",
@@ -62532,21 +62668,24 @@
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
-                "doctrine/dbal": "^2.13.1|^3.0",
-                "predis/predis": "^1.1",
+                "doctrine/dbal": "^2.13.1|^3|^4",
+                "predis/predis": "^1.1|^2.0",
                 "psr/simple-cache": "^1.0|^2.0|^3.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/messenger": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Cache\\": ""
                 },
+                "classmap": [
+                    "Traits/ValueWrapper.php"
+                ],
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -62572,7 +62711,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.0.19"
+                "source": "https://github.com/symfony/cache/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -62588,33 +62727,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-11-24T19:28:07+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.0.2",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "1c0a181c9ee221afe4fa55b2d13fc63c5ae14348"
+                "reference": "1d74b127da04ffa87aa940abe15446fa89653778"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/1c0a181c9ee221afe4fa55b2d13fc63c5ae14348",
-                "reference": "1c0a181c9ee221afe4fa55b2d13fc63c5ae14348",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/1d74b127da04ffa87aa940abe15446fa89653778",
+                "reference": "1d74b127da04ffa87aa940abe15446fa89653778",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/cache": "^3.0"
-            },
-            "suggest": {
-                "symfony/cache-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -62651,7 +62787,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -62667,7 +62803,81 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-09-25T12:52:38+00:00"
+        },
+        {
+            "name": "symfony/clock",
+            "version": "v7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/clock.git",
+                "reference": "c696b075befdd4bcffe5ef2eab9a32a1a9c0d29d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/c696b075befdd4bcffe5ef2eab9a32a1a9c0d29d",
+                "reference": "c696b075befdd4bcffe5ef2eab9a32a1a9c0d29d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/now.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Clock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Decouples applications from the system clock",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clock",
+                "psr20",
+                "time"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/clock/tree/v7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-25T20:15:12+00:00"
         },
         {
             "name": "symfony/config",
@@ -62746,23 +62956,24 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "a550a7c99daeedef3f9d23fb82e3531525ff11fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a550a7c99daeedef3f9d23fb82e3531525ff11fd",
+                "reference": "a550a7c99daeedef3f9d23fb82e3531525ff11fd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.4|^6.0"
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^5.4|^6.0|^7.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<5.4",
@@ -62776,18 +62987,16 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/lock": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -62816,12 +63025,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.4.1"
             },
             "funding": [
                 {
@@ -62837,7 +63046,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-11-30T10:54:28+00:00"
         },
         {
             "name": "symfony/debug",
@@ -62910,30 +63119,30 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.0.20",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "359806e1adebd1c43e18e5ea22acd14bef7fcf8c"
+                "reference": "f88ff6428afbeb17cc648c8003bd608534750baf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/359806e1adebd1c43e18e5ea22acd14bef7fcf8c",
-                "reference": "359806e1adebd1c43e18e5ea22acd14bef7fcf8c",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f88ff6428afbeb17cc648c8003bd608534750baf",
+                "reference": "f88ff6428afbeb17cc648c8003bd608534750baf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php81": "^1.22",
-                "symfony/service-contracts": "^1.1.6|^2.0|^3.0"
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.2.10|^7.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
-                "symfony/config": "<5.4",
+                "symfony/config": "<6.1",
                 "symfony/finder": "<5.4",
-                "symfony/proxy-manager-bridge": "<5.4",
+                "symfony/proxy-manager-bridge": "<6.3",
                 "symfony/yaml": "<5.4"
             },
             "provide": {
@@ -62941,16 +63150,9 @@
                 "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/config": "",
-                "symfony/expression-language": "For using expressions in service container configuration",
-                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
-                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
-                "symfony/yaml": ""
+                "symfony/config": "^6.1|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -62978,7 +63180,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.0.20"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.1"
             },
             "funding": [
                 {
@@ -62994,29 +63196,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-30T15:41:07+00:00"
+            "time": "2023-12-01T14:56:37+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -63045,7 +63247,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -63061,28 +63263,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "9cee123707e689f7e06c09624c145d206468bcf2"
+                "reference": "d0d584a91422ddaa2c94317200d4c4e5b935555f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/9cee123707e689f7e06c09624c145d206468bcf2",
-                "reference": "9cee123707e689f7e06c09624c145d206468bcf2",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/d0d584a91422ddaa2c94317200d4c4e5b935555f",
+                "reference": "d0d584a91422ddaa2c94317200d4c4e5b935555f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
+            },
+            "conflict": {
+                "symfony/console": "<5.4",
+                "symfony/process": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0"
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63115,7 +63321,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v6.0.19"
+                "source": "https://github.com/symfony/dotenv/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -63131,31 +63337,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-10-26T18:19:48+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "c7df52182f43a68522756ac31a532dd5b1e6db67"
+                "reference": "c873490a1c97b3a0a4838afc36ff36c112d02788"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c7df52182f43a68522756ac31a532dd5b1e6db67",
-                "reference": "c7df52182f43a68522756ac31a532dd5b1e6db67",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c873490a1c97b3a0a4838afc36ff36c112d02788",
+                "reference": "c873490a1c97b3a0a4838afc36ff36c112d02788",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "conflict": {
+                "symfony/deprecation-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4"
             },
             "require-dev": {
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0"
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/serializer": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/patch-type-declarations"
@@ -63186,7 +63396,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.0.19"
+                "source": "https://github.com/symfony/error-handler/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -63202,28 +63412,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-10-18T09:43:34+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "2eaf8e63bc5b8cefabd4a800157f0d0c094f677a"
+                "reference": "d76d2632cfc2206eecb5ad2b26cd5934082941b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/2eaf8e63bc5b8cefabd4a800157f0d0c094f677a",
-                "reference": "2eaf8e63bc5b8cefabd4a800157f0d0c094f677a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d76d2632cfc2206eecb5ad2b26cd5934082941b6",
+                "reference": "d76d2632cfc2206eecb5ad2b26cd5934082941b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/event-dispatcher-contracts": "^2|^3"
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/service-contracts": "<2.5"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
@@ -63231,17 +63442,13 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63269,7 +63476,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.19"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -63285,33 +63492,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-07-27T06:52:43+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.0.2",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051"
+                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7bc61cc2db649b4637d331240c5346dcc7708051",
-                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df",
+                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/event-dispatcher": "^1"
-            },
-            "suggest": {
-                "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -63348,7 +63552,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -63364,24 +63568,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "reference": "952a8cb588c3bc6ce76f6023000fb932f16a6e59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/952a8cb588c3bc6ce76f6023000fb932f16a6e59",
+                "reference": "952a8cb588c3bc6ce76f6023000fb932f16a6e59",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -63411,7 +63615,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -63427,24 +63631,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-07-26T17:27:13+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5cc9cac6586fc0c28cd173780ca696e419fefa11"
+                "reference": "11d736e97f116ac375a81f96e662911a34cd50ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5cc9cac6586fc0c28cd173780ca696e419fefa11",
-                "reference": "5cc9cac6586fc0c28cd173780ca696e419fefa11",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/11d736e97f116ac375a81f96e662911a34cd50ce",
+                "reference": "11d736e97f116ac375a81f96e662911a34cd50ce",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63472,7 +63679,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.0.19"
+                "source": "https://github.com/symfony/finder/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -63488,20 +63695,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-10-31T17:30:12+00:00"
         },
         {
             "name": "symfony/flex",
-            "version": "v2.3.1",
+            "version": "v2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "3c9c3424efdafe33e0e3cfb5e87e50b34711fedf"
+                "reference": "67ee785f1aedada76461de7a7ec10cd7f8ff8d36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/3c9c3424efdafe33e0e3cfb5e87e50b34711fedf",
-                "reference": "3c9c3424efdafe33e0e3cfb5e87e50b34711fedf",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/67ee785f1aedada76461de7a7ec10cd7f8ff8d36",
+                "reference": "67ee785f1aedada76461de7a7ec10cd7f8ff8d36",
                 "shasum": ""
             },
             "require": {
@@ -63537,7 +63744,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v2.3.1"
+                "source": "https://github.com/symfony/flex/tree/v2.4.2"
             },
             "funding": [
                 {
@@ -63553,67 +63760,60 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-27T07:38:25+00:00"
+            "time": "2023-12-05T14:09:35+00:00"
         },
         {
             "name": "symfony/form",
-            "version": "v6.2.5",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "5504c29b365c814132c087136935b50849411b09"
+                "reference": "10649ab710b58a04bcf1886f005ccab58d9cf0a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/5504c29b365c814132c087136935b50849411b09",
-                "reference": "5504c29b365c814132c087136935b50849411b09",
+                "url": "https://api.github.com/repos/symfony/form/zipball/10649ab710b58a04bcf1886f005ccab58d9cf0a4",
+                "reference": "10649ab710b58a04bcf1886f005ccab58d9cf0a4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/options-resolver": "^5.4|^6.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/options-resolver": "^5.4|^6.0|^7.0",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-icu": "^1.21",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3"
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.3",
                 "symfony/console": "<5.4",
                 "symfony/dependency-injection": "<5.4",
-                "symfony/doctrine-bridge": "<5.4",
+                "symfony/doctrine-bridge": "<5.4.21|>=6,<6.2.7",
                 "symfony/error-handler": "<5.4",
                 "symfony/framework-bundle": "<5.4",
                 "symfony/http-kernel": "<5.4",
                 "symfony/translation": "<5.4",
-                "symfony/translation-contracts": "<1.1.7",
-                "symfony/twig-bridge": "<5.4"
+                "symfony/translation-contracts": "<2.5",
+                "symfony/twig-bridge": "<6.3"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0|^2.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/html-sanitizer": "^6.1",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
-                "symfony/security-core": "^6.2",
-                "symfony/security-csrf": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/validator": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/security-core": "For hashing users passwords.",
-                "symfony/security-csrf": "For protecting forms against CSRF attacks.",
-                "symfony/twig-bridge": "For templating with Twig.",
-                "symfony/validator": "For form validation."
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/html-sanitizer": "^6.1|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/security-core": "^6.2|^7.0",
+                "symfony/security-csrf": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4|^6.0|^7.0",
+                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63641,7 +63841,7 @@
             "description": "Allows to easily create, process and reuse HTML forms",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/form/tree/v6.2.5"
+                "source": "https://github.com/symfony/form/tree/v6.4.1"
             },
             "funding": [
                 {
@@ -63657,37 +63857,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:38:09+00:00"
+            "time": "2023-11-30T11:08:34+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v6.0.19",
+            "version": "v6.2.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "ee403597484be1073222373fc2962b44c36f5dd4"
+                "reference": "331d13a47e5f1d95c0064cfa043421051af7c56b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/ee403597484be1073222373fc2962b44c36f5dd4",
-                "reference": "ee403597484be1073222373fc2962b44c36f5dd4",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/331d13a47e5f1d95c0064cfa043421051af7c56b",
+                "reference": "331d13a47e5f1d95c0064cfa043421051af7c56b",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": ">=2.1",
                 "ext-xml": "*",
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4.5|^6.0.5",
-                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/config": "^6.1",
+                "symfony/dependency-injection": "^6.2.8",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/error-handler": "^6.1",
                 "symfony/event-dispatcher": "^5.4|^6.0",
                 "symfony/filesystem": "^5.4|^6.0",
                 "symfony/finder": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/http-foundation": "^6.2.11",
+                "symfony/http-kernel": "^6.2.1",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php81": "^1.22",
                 "symfony/routing": "^5.4|^6.0"
             },
             "conflict": {
@@ -63695,7 +63895,6 @@
                 "doctrine/persistence": "<1.3",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
-                "phpunit/phpunit": "<5.4.3",
                 "symfony/asset": "<5.4",
                 "symfony/console": "<5.4",
                 "symfony/dom-crawler": "<5.4",
@@ -63704,15 +63903,15 @@
                 "symfony/http-client": "<5.4",
                 "symfony/lock": "<5.4",
                 "symfony/mailer": "<5.4",
-                "symfony/messenger": "<5.4",
-                "symfony/mime": "<5.4",
+                "symfony/messenger": "<6.2",
+                "symfony/mime": "<6.2",
                 "symfony/property-access": "<5.4",
                 "symfony/property-info": "<5.4",
                 "symfony/security-core": "<5.4",
                 "symfony/security-csrf": "<5.4",
-                "symfony/serializer": "<5.4",
+                "symfony/serializer": "<6.1",
                 "symfony/stopwatch": "<5.4",
-                "symfony/translation": "<5.4",
+                "symfony/translation": "<6.2.8",
                 "symfony/twig-bridge": "<5.4",
                 "symfony/twig-bundle": "<5.4",
                 "symfony/validator": "<5.4",
@@ -63731,22 +63930,25 @@
                 "symfony/dotenv": "^5.4|^6.0",
                 "symfony/expression-language": "^5.4|^6.0",
                 "symfony/form": "^5.4|^6.0",
+                "symfony/html-sanitizer": "^6.1",
                 "symfony/http-client": "^5.4|^6.0",
                 "symfony/lock": "^5.4|^6.0",
                 "symfony/mailer": "^5.4|^6.0",
-                "symfony/messenger": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
+                "symfony/messenger": "^6.2",
+                "symfony/mime": "^6.2",
                 "symfony/notifier": "^5.4|^6.0",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/process": "^5.4|^6.0",
                 "symfony/property-info": "^5.4|^6.0",
                 "symfony/rate-limiter": "^5.4|^6.0",
                 "symfony/security-bundle": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0",
+                "symfony/semaphore": "^5.4|^6.0",
+                "symfony/serializer": "^6.1",
                 "symfony/stopwatch": "^5.4|^6.0",
                 "symfony/string": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
+                "symfony/translation": "^6.2.8",
                 "symfony/twig-bundle": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
                 "symfony/validator": "^5.4|^6.0",
                 "symfony/web-link": "^5.4|^6.0",
                 "symfony/workflow": "^5.4|^6.0",
@@ -63789,7 +63991,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v6.0.19"
+                "source": "https://github.com/symfony/framework-bundle/tree/v6.2.13"
             },
             "funding": [
                 {
@@ -63805,27 +64007,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T11:50:03+00:00"
+            "time": "2023-07-26T17:38:53+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.0.20",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "541c04560da1875f62c963c3aab6ea12a7314e11"
+                "reference": "5c584530b77aa10ae216989ffc48b4bedc9c0b29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/541c04560da1875f62c963c3aab6ea12a7314e11",
-                "reference": "541c04560da1875f62c963c3aab6ea12a7314e11",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/5c584530b77aa10ae216989ffc48b4bedc9c0b29",
+                "reference": "5c584530b77aa10ae216989ffc48b4bedc9c0b29",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/http-client-contracts": "^3",
-                "symfony/service-contracts": "^1.0|^2|^3"
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.3"
             },
             "provide": {
                 "php-http/async-client-implementation": "*",
@@ -63842,10 +64049,11 @@
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/stopwatch": "^5.4|^6.0"
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -63872,8 +64080,11 @@
             ],
             "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.0.20"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -63889,32 +64100,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-30T15:41:07+00:00"
+            "time": "2023-11-28T20:55:58+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.0.2",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "4184b9b63af1edaf35b6a7974c6f1f9f33294129"
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4184b9b63af1edaf35b6a7974c6f1f9f33294129",
-                "reference": "4184b9b63af1edaf35b6a7974c6f1f9f33294129",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/1ee70e699b41909c209a0c930f11034b93578654",
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
-            },
-            "suggest": {
-                "symfony/http-client-implementation": ""
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -63924,7 +64132,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\HttpClient\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -63951,7 +64162,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -63967,38 +64178,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-12T16:11:42+00:00"
+            "time": "2023-07-30T20:28:31+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.0.20",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "e16b2676a4b3b1fa12378a20b29c364feda2a8d6"
+                "reference": "44a6d39a9cc11e154547d882d5aac1e014440771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e16b2676a4b3b1fa12378a20b29c364feda2a8d6",
-                "reference": "e16b2676a4b3b1fa12378a20b29c364feda2a8d6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/44a6d39a9cc11e154547d882d5aac1e014440771",
+                "reference": "44a6d39a9cc11e154547d882d5aac1e014440771",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-mbstring": "~1.1"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php83": "^1.27"
+            },
+            "conflict": {
+                "symfony/cache": "<6.3"
             },
             "require-dev": {
-                "predis/predis": "~1.0",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/rate-limiter": "^5.2|^6.0"
-            },
-            "suggest": {
-                "symfony/mime": "To use the file extension guesser"
+                "doctrine/dbal": "^2.13.1|^3|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.3|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/rate-limiter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64026,7 +64239,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.0.20"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -64042,44 +64255,48 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-30T15:41:07+00:00"
+            "time": "2023-11-20T16:41:16+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.0.20",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "6dc70833fd0ef5e861e17c7854c12d7d86679349"
+                "reference": "2953274c16a229b3933ef73a6898e18388e12e1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6dc70833fd0ef5e861e17c7854c12d7d86679349",
-                "reference": "6dc70833fd0ef5e861e17c7854c12d7d86679349",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/2953274c16a229b3933ef73a6898e18388e12e1b",
+                "reference": "2953274c16a229b3933ef73a6898e18388e12e1b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "symfony/browser-kit": "<5.4",
                 "symfony/cache": "<5.4",
-                "symfony/config": "<5.4",
+                "symfony/config": "<6.1",
                 "symfony/console": "<5.4",
-                "symfony/dependency-injection": "<5.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/doctrine-bridge": "<5.4",
                 "symfony/form": "<5.4",
                 "symfony/http-client": "<5.4",
+                "symfony/http-client-contracts": "<2.5",
                 "symfony/mailer": "<5.4",
                 "symfony/messenger": "<5.4",
                 "symfony/translation": "<5.4",
+                "symfony/translation-contracts": "<2.5",
                 "symfony/twig-bridge": "<5.4",
-                "symfony/validator": "<5.4",
+                "symfony/validator": "<6.4",
+                "symfony/var-dumper": "<6.3",
                 "twig/twig": "<2.13"
             },
             "provide": {
@@ -64087,27 +64304,27 @@
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/css-selector": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/dom-crawler": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/http-client-contracts": "^1.1|^2|^3",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/routing": "^5.4|^6.0",
-                "symfony/stopwatch": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
-                "symfony/translation-contracts": "^1.1|^2|^3",
+                "symfony/browser-kit": "^5.4|^6.0|^7.0",
+                "symfony/clock": "^6.2|^7.0",
+                "symfony/config": "^6.1|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/css-selector": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/dom-crawler": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/http-client-contracts": "^2.5|^3",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4.5|^6.0.5|^7.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.3|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4|^6.0|^7.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-exporter": "^6.2|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
-            },
-            "suggest": {
-                "symfony/browser-kit": "",
-                "symfony/config": "",
-                "symfony/console": "",
-                "symfony/dependency-injection": ""
             },
             "type": "library",
             "autoload": {
@@ -64135,7 +64352,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.0.20"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.1"
             },
             "funding": [
                 {
@@ -64151,27 +64368,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-01T08:22:55+00:00"
+            "time": "2023-12-01T17:02:02+00:00"
         },
         {
             "name": "symfony/intl",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "a2e1ce9048ea549ee1e8d9ce521cbe9a9ec7d92c"
+                "reference": "41d16f0294b9ca6e5540728580c65cfa3848fbf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/a2e1ce9048ea549ee1e8d9ce521cbe9a9ec7d92c",
-                "reference": "a2e1ce9048ea549ee1e8d9ce521cbe9a9ec7d92c",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/41d16f0294b9ca6e5540728580c65cfa3848fbf5",
+                "reference": "41d16f0294b9ca6e5540728580c65cfa3848fbf5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "symfony/filesystem": "^5.4|^6.0"
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64204,7 +64423,7 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Provides a PHP replacement layer for the C intl extension that includes additional data from the ICU library",
+            "description": "Provides access to the localization data of the ICU library",
             "homepage": "https://symfony.com",
             "keywords": [
                 "i18n",
@@ -64215,7 +64434,7 @@
                 "localization"
             ],
             "support": {
-                "source": "https://github.com/symfony/intl/tree/v6.0.19"
+                "source": "https://github.com/symfony/intl/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -64231,7 +64450,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-10-28T23:12:08+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -64311,44 +64530,46 @@
         },
         {
             "name": "symfony/messenger",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "d584d1754e9e19f83a43c75f36c84b42f6f7e209"
+                "reference": "a6f32d0e9b9c7d2d47c7bea3cd1e8a9c0f781fb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/d584d1754e9e19f83a43c75f36c84b42f6f7e209",
-                "reference": "d584d1754e9e19f83a43c75f36c84b42f6f7e209",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/a6f32d0e9b9c7d2d47c7bea3cd1e8a9c0f781fb4",
+                "reference": "a6f32d0e9b9c7d2d47c7bea3cd1e8a9c0f781fb4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "psr/log": "^1|^2|^3"
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/clock": "^6.3|^7.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
+                "symfony/console": "<6.3",
                 "symfony/event-dispatcher": "<5.4",
+                "symfony/event-dispatcher-contracts": "<2.5",
                 "symfony/framework-bundle": "<5.4",
                 "symfony/http-kernel": "<5.4",
                 "symfony/serializer": "<5.4"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/routing": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^5.4|^6.0",
-                "symfony/validator": "^5.4|^6.0"
-            },
-            "suggest": {
-                "enqueue/messenger-adapter": "For using the php-enqueue library as a transport."
+                "symfony/console": "^6.3|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/rate-limiter": "^5.4|^6.0|^7.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64376,7 +64597,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v6.0.19"
+                "source": "https://github.com/symfony/messenger/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -64392,24 +64613,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-11-24T19:28:07+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "d7052547a0070cbeadd474e172b527a00d657301"
+                "reference": "ca4f58b2ef4baa8f6cecbeca2573f88cd577d205"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/d7052547a0070cbeadd474e172b527a00d657301",
-                "reference": "d7052547a0070cbeadd474e172b527a00d657301",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/ca4f58b2ef4baa8f6cecbeca2573f88cd577d205",
+                "reference": "ca4f58b2ef4baa8f6cecbeca2573f88cd577d205",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
@@ -64418,15 +64640,16 @@
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/mailer": "<5.4",
-                "symfony/serializer": "<5.4.14|>=6.0,<6.0.14|>=6.1,<6.1.6"
+                "symfony/serializer": "<6.3.2"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/serializer": "^5.4.14|~6.0.14|^6.1.6"
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.3.2|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64458,7 +64681,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.0.19"
+                "source": "https://github.com/symfony/mime/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -64474,20 +64697,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T11:50:03+00:00"
+            "time": "2023-10-17T11:49:05+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v5.4.22",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "34be6f0695e4187dbb832a05905fb4c6581ac39a"
+                "reference": "3e295d9b0a873476356cb6cff0ce39b3f528b387"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/34be6f0695e4187dbb832a05905fb4c6581ac39a",
-                "reference": "34be6f0695e4187dbb832a05905fb4c6581ac39a",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/3e295d9b0a873476356cb6cff0ce39b3f528b387",
+                "reference": "3e295d9b0a873476356cb6cff0ce39b3f528b387",
                 "shasum": ""
             },
             "require": {
@@ -64542,7 +64765,7 @@
             "description": "Provides integration for Monolog with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/monolog-bridge/tree/v5.4.22"
+                "source": "https://github.com/symfony/monolog-bridge/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -64558,34 +64781,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-06T21:29:33+00:00"
+            "time": "2023-10-31T07:58:33+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "v3.8.0",
+            "version": "v3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "a41bbcdc1105603b6d73a7d9a43a3788f8e0fb7d"
+                "reference": "414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/a41bbcdc1105603b6d73a7d9a43a3788f8e0fb7d",
-                "reference": "a41bbcdc1105603b6d73a7d9a43a3788f8e0fb7d",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181",
+                "reference": "414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181",
                 "shasum": ""
             },
             "require": {
-                "monolog/monolog": "^1.22 || ^2.0 || ^3.0",
-                "php": ">=7.1.3",
-                "symfony/config": "~4.4 || ^5.0 || ^6.0",
-                "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
-                "symfony/http-kernel": "~4.4 || ^5.0 || ^6.0",
-                "symfony/monolog-bridge": "~4.4 || ^5.0 || ^6.0"
+                "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
+                "php": ">=7.2.5",
+                "symfony/config": "^5.4 || ^6.0 || ^7.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+                "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0"
             },
             "require-dev": {
-                "symfony/console": "~4.4 || ^5.0 || ^6.0",
-                "symfony/phpunit-bridge": "^5.2 || ^6.0",
-                "symfony/yaml": "~4.4 || ^5.0 || ^6.0"
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^6.3 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -64623,7 +64846,7 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/monolog-bundle/issues",
-                "source": "https://github.com/symfony/monolog-bundle/tree/v3.8.0"
+                "source": "https://github.com/symfony/monolog-bundle/tree/v3.10.0"
             },
             "funding": [
                 {
@@ -64639,25 +64862,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T14:24:36+00:00"
+            "time": "2023-11-06T17:08:13+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "6a180d1c45e0d9797470ca9eb46215692de00fa3"
+                "reference": "22301f0e7fdeaacc14318928612dee79be99860e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/6a180d1c45e0d9797470ca9eb46215692de00fa3",
-                "reference": "6a180d1c45e0d9797470ca9eb46215692de00fa3",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/22301f0e7fdeaacc14318928612dee79be99860e",
+                "reference": "22301f0e7fdeaacc14318928612dee79be99860e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/deprecation-contracts": "^2.1|^3"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "type": "library",
             "autoload": {
@@ -64690,7 +64913,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.0.19"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -64706,31 +64929,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-08-08T10:16:24+00:00"
         },
         {
             "name": "symfony/password-hasher",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/password-hasher.git",
-                "reference": "2ae49765c5328307e82c0ee2898a39c071ef5bc8"
+                "reference": "e001f752338a49d644ee0523fd7891aabaccb7e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/2ae49765c5328307e82c0ee2898a39c071ef5bc8",
-                "reference": "2ae49765c5328307e82c0ee2898a39c071ef5bc8",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/e001f752338a49d644ee0523fd7891aabaccb7e2",
+                "reference": "e001f752338a49d644ee0523fd7891aabaccb7e2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "conflict": {
                 "symfony/security-core": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0",
-                "symfony/security-core": "^5.4|^6.0"
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/security-core": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -64762,7 +64985,7 @@
                 "password"
             ],
             "support": {
-                "source": "https://github.com/symfony/password-hasher/tree/v6.0.19"
+                "source": "https://github.com/symfony/password-hasher/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -64778,20 +65001,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-11-06T11:00:25+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
@@ -64803,7 +65026,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -64843,7 +65066,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -64859,20 +65082,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "a3d9148e2c363588e05abbdd4ee4f971f0a5330c"
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/a3d9148e2c363588e05abbdd4ee4f971f0a5330c",
-                "reference": "a3d9148e2c363588e05abbdd4ee4f971f0a5330c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/e46b4da57951a16053cd751f63f4a24292788157",
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157",
                 "shasum": ""
             },
             "require": {
@@ -64884,7 +65107,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -64930,7 +65153,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -64946,20 +65169,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-03-21T17:27:24+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
                 "shasum": ""
             },
             "require": {
@@ -64973,7 +65196,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -65017,7 +65240,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -65033,20 +65256,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:30:37+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
                 "shasum": ""
             },
             "require": {
@@ -65058,7 +65281,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -65101,7 +65324,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -65117,20 +65340,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -65145,7 +65368,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -65184,7 +65407,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -65200,20 +65423,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
                 "shasum": ""
             },
             "require": {
@@ -65222,7 +65445,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -65263,7 +65486,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -65279,20 +65502,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
                 "shasum": ""
             },
             "require": {
@@ -65301,7 +65524,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -65346,86 +65569,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.28.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
-                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -65523,17 +65667,97 @@
             "time": "2023-08-25T17:27:25+00:00"
         },
         {
-            "name": "symfony/polyfill-uuid",
-            "version": "v1.27.0",
+            "name": "symfony/polyfill-php83",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "f3cf1a645c2734236ed1e2e671e273eeb3586166"
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/f3cf1a645c2734236ed1e2e671e273eeb3586166",
-                "reference": "f3cf1a645c2734236ed1e2e671e273eeb3586166",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-php80": "^1.14"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-16T06:22:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/9c44518a5aff8da565c8a55dbe85d2769e6f630e",
+                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e",
                 "shasum": ""
             },
             "require": {
@@ -65548,7 +65772,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -65586,7 +65810,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -65602,24 +65826,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "2114fd60f26a296cc403a7939ab91478475a33d4"
+                "reference": "191703b1566d97a5425dc969e4350d32b8ef17aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2114fd60f26a296cc403a7939ab91478475a33d4",
-                "reference": "2114fd60f26a296cc403a7939ab91478475a33d4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/191703b1566d97a5425dc969e4350d32b8ef17aa",
+                "reference": "191703b1566d97a5425dc969e4350d32b8ef17aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -65647,7 +65871,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.0.19"
+                "source": "https://github.com/symfony/process/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -65663,31 +65887,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-11-17T21:06:49+00:00"
         },
         {
             "name": "symfony/property-access",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "cae9aadf6e3a08315af666d4fede905fbb5b5393"
+                "reference": "75f6990ae8e8040dd587162f3f1863f755957129"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/cae9aadf6e3a08315af666d4fede905fbb5b5393",
-                "reference": "cae9aadf6e3a08315af666d4fede905fbb5b5393",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/75f6990ae8e8040dd587162f3f1863f755957129",
+                "reference": "75f6990ae8e8040dd587162f3f1863f755957129",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/property-info": "^5.4|^6.0"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/property-info": "^5.4|^6.0|^7.0"
             },
             "require-dev": {
-                "symfony/cache": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/cache-implementation": "To cache access methods."
+                "symfony/cache": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -65722,11 +65944,11 @@
                 "injection",
                 "object",
                 "property",
-                "property path",
+                "property-path",
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v6.0.19"
+                "source": "https://github.com/symfony/property-access/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -65742,44 +65964,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-09-25T12:52:38+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v6.0.19",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "e6dfb2223b21768d3b2ae033a5e1f9d205184d45"
+                "reference": "ce627df05f5629ce4feec536ee827ad0a12689b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/e6dfb2223b21768d3b2ae033a5e1f9d205184d45",
-                "reference": "e6dfb2223b21768d3b2ae033a5e1f9d205184d45",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/ce627df05f5629ce4feec536ee827ad0a12689b6",
+                "reference": "ce627df05f5629ce4feec536ee827ad0a12689b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/string": "^5.4|^6.0"
+                "php": ">=8.2",
+                "symfony/string": "^6.4|^7.0"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<5.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/dependency-injection": "<5.4"
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/serializer": "<6.4"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.10.4|^2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "phpstan/phpdoc-parser": "^1.0",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0"
-            },
-            "suggest": {
-                "phpdocumentor/reflection-docblock": "To use the PHPDoc",
-                "psr/cache-implementation": "To cache results",
-                "symfony/doctrine-bridge": "To use Doctrine metadata",
-                "symfony/serializer": "To use Serializer metadata"
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -65815,7 +66031,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v6.0.19"
+                "source": "https://github.com/symfony/property-info/tree/v7.0.0"
             },
             "funding": [
                 {
@@ -65831,45 +66047,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-15T17:21:41+00:00"
+            "time": "2023-11-25T08:38:27+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v6.0.19",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "e56ca9b41c1ec447193474cd86ad7c0b547755ac"
+                "reference": "0c95c164fdba18b12523b75e64199ca3503e6d40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/e56ca9b41c1ec447193474cd86ad7c0b547755ac",
-                "reference": "e56ca9b41c1ec447193474cd86ad7c0b547755ac",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/0c95c164fdba18b12523b75e64199ca3503e6d40",
+                "reference": "0c95c164fdba18b12523b75e64199ca3503e6d40",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "doctrine/annotations": "<1.12",
-                "symfony/config": "<5.4",
+                "symfony/config": "<6.2",
                 "symfony/dependency-injection": "<5.4",
                 "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/config": "For using the all-in-one router or any loader",
-                "symfony/expression-language": "For using expression matching",
-                "symfony/http-foundation": "For using a Symfony Request object",
-                "symfony/yaml": "For using the YAML loader"
+                "symfony/config": "^6.2|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -65903,7 +66114,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.0.19"
+                "source": "https://github.com/symfony/routing/tree/v6.4.1"
             },
             "funding": [
                 {
@@ -65919,35 +66130,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-12-01T14:54:37+00:00"
         },
         {
             "name": "symfony/runtime",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/runtime.git",
-                "reference": "043ac3b6c0b6749bb6848efe490abeb04f1e3ccd"
+                "reference": "86539231fadfdc7f7e9911d6fa7ed84a606e7d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/runtime/zipball/043ac3b6c0b6749bb6848efe490abeb04f1e3ccd",
-                "reference": "043ac3b6c0b6749bb6848efe490abeb04f1e3ccd",
+                "url": "https://api.github.com/repos/symfony/runtime/zipball/86539231fadfdc7f7e9911d6fa7ed84a606e7d34",
+                "reference": "86539231fadfdc7f7e9911d6fa7ed84a606e7d34",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0|^2.0",
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "conflict": {
                 "symfony/dotenv": "<5.4"
             },
             "require-dev": {
                 "composer/composer": "^1.0.2|^2.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dotenv": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0"
+                "symfony/console": "^5.4.9|^6.0.9|^7.0",
+                "symfony/dotenv": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -65978,8 +66189,11 @@
             ],
             "description": "Enables decoupling PHP applications from global state",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "runtime"
+            ],
             "support": {
-                "source": "https://github.com/symfony/runtime/tree/v6.0.19"
+                "source": "https://github.com/symfony/runtime/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -65995,20 +66209,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-10-18T09:43:34+00:00"
         },
         {
             "name": "symfony/security-core",
-            "version": "v5.4.22",
+            "version": "v5.4.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "a801d525c7545332e2ddf7f52c163959354b1650"
+                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/a801d525c7545332e2ddf7f52c163959354b1650",
-                "reference": "a801d525c7545332e2ddf7f52c163959354b1650",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/3908c54da30dd68c2fe31915d82a1c81809d1928",
+                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928",
                 "shasum": ""
             },
             "require": {
@@ -66072,7 +66286,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v5.4.22"
+                "source": "https://github.com/symfony/security-core/tree/v5.4.30"
             },
             "funding": [
                 {
@@ -66088,34 +66302,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-10T10:02:45+00:00"
+            "time": "2023-10-27T07:38:28+00:00"
         },
         {
             "name": "symfony/security-csrf",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-csrf.git",
-                "reference": "150d0a78b14737f66e4b2e7be7d0ec2522c453ed"
+                "reference": "b28413496ebfce2f98afbb990ad0ce0ba3586638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/150d0a78b14737f66e4b2e7be7d0ec2522c453ed",
-                "reference": "150d0a78b14737f66e4b2e7be7d0ec2522c453ed",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/b28413496ebfce2f98afbb990ad0ce0ba3586638",
+                "reference": "b28413496ebfce2f98afbb990ad0ce0ba3586638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/security-core": "^5.4|^6.0"
+                "php": ">=8.1",
+                "symfony/security-core": "^5.4|^6.0|^7.0"
             },
             "conflict": {
                 "symfony/http-foundation": "<5.4"
             },
             "require-dev": {
-                "symfony/http-foundation": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/http-foundation": "For using the class SessionTokenStorage."
+                "symfony/http-foundation": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -66143,7 +66354,7 @@
             "description": "Symfony Security Component - CSRF Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-csrf/tree/v6.0.19"
+                "source": "https://github.com/symfony/security-csrf/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -66159,24 +66370,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-08-25T16:27:31+00:00"
         },
         {
             "name": "symfony/security-guard",
-            "version": "v5.4.22",
+            "version": "v5.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-guard.git",
-                "reference": "62d064b1ee682e4617f4c5ddc0d31f73e1a7ecaa"
+                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-guard/zipball/62d064b1ee682e4617f4c5ddc0d31f73e1a7ecaa",
-                "reference": "62d064b1ee682e4617f4c5ddc0d31f73e1a7ecaa",
+                "url": "https://api.github.com/repos/symfony/security-guard/zipball/72c53142533462fc6fda4a429c2a21c2b944a8cc",
+                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-php80": "^1.15",
                 "symfony/security-core": "^5.0",
                 "symfony/security-http": "^5.3"
@@ -66210,7 +66422,7 @@
             "description": "Symfony Security Component - Guard",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-guard/tree/v5.4.22"
+                "source": "https://github.com/symfony/security-guard/tree/v5.4.27"
             },
             "funding": [
                 {
@@ -66226,20 +66438,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-06T21:29:33+00:00"
+            "time": "2023-07-28T14:44:35+00:00"
         },
         {
             "name": "symfony/security-http",
-            "version": "v5.4.23",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "6791856229cc605834d169091981e4eae77dad45"
+                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/6791856229cc605834d169091981e4eae77dad45",
-                "reference": "6791856229cc605834d169091981e4eae77dad45",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/6d3cd5a4deee9697738db8d24258890ca4140ae9",
+                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9",
                 "shasum": ""
             },
             "require": {
@@ -66250,7 +66462,8 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "^1.16",
                 "symfony/property-access": "^4.4|^5.0|^6.0",
-                "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5"
+                "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5",
+                "symfony/service-contracts": "^1.10|^2|^3"
             },
             "conflict": {
                 "symfony/event-dispatcher": "<4.3",
@@ -66295,7 +66508,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v5.4.23"
+                "source": "https://github.com/symfony/security-http/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -66311,64 +66524,61 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-21T11:34:27+00:00"
+            "time": "2023-11-03T16:13:08+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.0.19",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "6aff9e2894ff0dcfa7aca38f9d0396ed65627d07"
+                "reference": "7ead272e62c9567df619ef3c49809bf934ddbc1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/6aff9e2894ff0dcfa7aca38f9d0396ed65627d07",
-                "reference": "6aff9e2894ff0dcfa7aca38f9d0396ed65627d07",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/7ead272e62c9567df619ef3c49809bf934ddbc1f",
+                "reference": "7ead272e62c9567df619ef3c49809bf934ddbc1f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "doctrine/annotations": "<1.12",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0|>=1.7.0",
+                "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/dependency-injection": "<5.4",
                 "symfony/property-access": "<5.4",
-                "symfony/property-info": "<5.4",
+                "symfony/property-info": "<5.4.24|>=6,<6.2.11",
                 "symfony/uid": "<5.4",
+                "symfony/validator": "<6.4",
                 "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/form": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/validator": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0",
-                "symfony/var-exporter": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/cache-implementation": "For using the metadata cache.",
-                "symfony/config": "For using the XML mapping loader.",
-                "symfony/mime": "For using a MIME type guesser within the DataUriNormalizer.",
-                "symfony/property-access": "For using the ObjectNormalizer.",
-                "symfony/property-info": "To deserialize relations.",
-                "symfony/var-exporter": "For using the metadata compiler.",
-                "symfony/yaml": "For using the default YAML mapping loader."
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/form": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4.24|^6.2.11|^7.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -66396,7 +66606,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.0.19"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.1"
             },
             "funding": [
                 {
@@ -66412,7 +66622,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-15T17:21:41+00:00"
+            "time": "2023-12-01T14:54:37+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -66499,21 +66709,21 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "011e781839dd1d2eb8119f65ac516a530f60226d"
+                "reference": "fc47f1015ec80927ff64ba9094dfe8b9d48fe9f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/011e781839dd1d2eb8119f65ac516a530f60226d",
-                "reference": "011e781839dd1d2eb8119f65ac516a530f60226d",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/fc47f1015ec80927ff64ba9094dfe8b9d48fe9f2",
+                "reference": "fc47f1015ec80927ff64ba9094dfe8b9d48fe9f2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/service-contracts": "^1|^2|^3"
+                "php": ">=8.1",
+                "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
             "autoload": {
@@ -66541,7 +66751,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v6.0.19"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -66557,37 +66767,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-02-16T10:14:28+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
+                "reference": "92bd2bfbba476d4a1838e5e12168bef2fd1e6620",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": "<2.0"
+                "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/translation-contracts": "^2.0|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0"
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -66626,7 +66837,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v7.0.0"
             },
             "funding": [
                 {
@@ -66642,32 +66853,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-11-29T08:40:23+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "9c24b3fdbbe9fb2ef3a6afd8bbaadfd72dad681f"
+                "reference": "b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/9c24b3fdbbe9fb2ef3a6afd8bbaadfd72dad681f",
-                "reference": "9c24b3fdbbe9fb2ef3a6afd8bbaadfd72dad681f",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37",
+                "reference": "b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.3|^3.0"
+                "symfony/translation-contracts": "^2.5|^3.0"
             },
             "conflict": {
                 "symfony/config": "<5.4",
                 "symfony/console": "<5.4",
                 "symfony/dependency-injection": "<5.4",
+                "symfony/http-client-contracts": "<2.5",
                 "symfony/http-kernel": "<5.4",
+                "symfony/service-contracts": "<2.5",
                 "symfony/twig-bundle": "<5.4",
                 "symfony/yaml": "<5.4"
             },
@@ -66675,22 +66889,19 @@
                 "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
+                "nikic/php-parser": "^4.13",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/http-client-contracts": "^1.1|^2.0|^3.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/service-contracts": "^1.1.2|^2|^3",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/log-implementation": "To use logging capability in translator",
-                "symfony/config": "",
-                "symfony/yaml": ""
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -66721,7 +66932,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.0.19"
+                "source": "https://github.com/symfony/translation/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -66737,32 +66948,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-11-29T08:14:36+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "acbfbb274e730e5a0236f619b6168d9dedb3e282"
+                "reference": "dee0c6e5b4c07ce851b462530088e64b255ac9c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/acbfbb274e730e5a0236f619b6168d9dedb3e282",
-                "reference": "acbfbb274e730e5a0236f619b6168d9dedb3e282",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/dee0c6e5b4c07ce851b462530088e64b255ac9c5",
+                "reference": "dee0c6e5b4c07ce851b462530088e64b255ac9c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
-            },
-            "suggest": {
-                "symfony/translation-implementation": ""
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -66772,7 +66980,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Translation\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -66799,7 +67010,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -66815,83 +67026,72 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-27T17:10:44+00:00"
+            "time": "2023-07-25T15:08:44+00:00"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "bcd79f7845f887defec9d6737a535a3c602159e9"
+                "reference": "142bc3ad4a61d7eedf7cc21d8ef2bd8a8e7417bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/bcd79f7845f887defec9d6737a535a3c602159e9",
-                "reference": "bcd79f7845f887defec9d6737a535a3c602159e9",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/142bc3ad4a61d7eedf7cc21d8ef2bd8a8e7417bf",
+                "reference": "142bc3ad4a61d7eedf7cc21d8ef2bd8a8e7417bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "symfony/translation-contracts": "^1.1|^2|^3",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/translation-contracts": "^2.5|^3",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/console": "<5.4",
-                "symfony/form": "<5.4",
+                "symfony/form": "<6.3",
                 "symfony/http-foundation": "<5.4",
-                "symfony/http-kernel": "<5.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/mime": "<6.2",
+                "symfony/serializer": "<6.4",
                 "symfony/translation": "<5.4",
                 "symfony/workflow": "<5.4"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.12|^2",
                 "egulias/email-validator": "^2.1.10|^3|^4",
+                "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/asset": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/form": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
+                "symfony/asset": "^5.4|^6.0|^7.0",
+                "symfony/asset-mapper": "^6.3|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/form": "^6.4|^7.0",
+                "symfony/html-sanitizer": "^6.1|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^6.2|^7.0",
                 "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/routing": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
                 "symfony/security-acl": "^2.8|^3.0",
-                "symfony/security-core": "^5.4|^6.0",
-                "symfony/security-csrf": "^5.4|^6.0",
-                "symfony/security-http": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0",
-                "symfony/stopwatch": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
-                "symfony/web-link": "^5.4|^6.0",
-                "symfony/workflow": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0",
+                "symfony/security-core": "^5.4|^6.0|^7.0",
+                "symfony/security-csrf": "^5.4|^6.0|^7.0",
+                "symfony/security-http": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^6.1|^7.0",
+                "symfony/web-link": "^5.4|^6.0|^7.0",
+                "symfony/workflow": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0",
                 "twig/cssinliner-extra": "^2.12|^3",
                 "twig/inky-extra": "^2.12|^3",
                 "twig/markdown-extra": "^2.12|^3"
-            },
-            "suggest": {
-                "symfony/asset": "For using the AssetExtension",
-                "symfony/expression-language": "For using the ExpressionExtension",
-                "symfony/finder": "",
-                "symfony/form": "For using the FormExtension",
-                "symfony/http-kernel": "For using the HttpKernelExtension",
-                "symfony/routing": "For using the RoutingExtension",
-                "symfony/security-core": "For using the SecurityExtension",
-                "symfony/security-csrf": "For using the CsrfExtension",
-                "symfony/security-http": "For using the LogoutUrlExtension",
-                "symfony/stopwatch": "For using the StopwatchExtension",
-                "symfony/translation": "For using the TranslationExtension",
-                "symfony/var-dumper": "For using the DumpExtension",
-                "symfony/web-link": "For using the WebLinkExtension",
-                "symfony/yaml": "For using the YamlExtension"
             },
             "type": "symfony-bridge",
             "autoload": {
@@ -66919,7 +67119,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v6.0.19"
+                "source": "https://github.com/symfony/twig-bridge/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -66935,28 +67135,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T11:50:03+00:00"
+            "time": "2023-11-25T08:25:13+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "6499e28b0ac9f2aa3151e11845bdb5cd21e6bb9d"
+                "reference": "8092dd1b1a41372110d06374f99ee62f7f0b9a92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/6499e28b0ac9f2aa3151e11845bdb5cd21e6bb9d",
-                "reference": "6499e28b0ac9f2aa3151e11845bdb5cd21e6bb9d",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/8092dd1b1a41372110d06374f99ee62f7f0b9a92",
+                "reference": "8092dd1b1a41372110d06374f99ee62f7f0b9a92",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-uuid": "^1.15"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -66993,7 +67193,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v6.0.19"
+                "source": "https://github.com/symfony/uid/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -67009,33 +67209,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-10-31T08:18:17+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "8e41a2dc215903964175ca8bdc884297f021d31c"
+                "reference": "33e1f3bb76ef70e3170e12f878aefb9c69b0fc4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/8e41a2dc215903964175ca8bdc884297f021d31c",
-                "reference": "8e41a2dc215903964175ca8bdc884297f021d31c",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/33e1f3bb76ef70e3170e12f878aefb9c69b0fc4c",
+                "reference": "33e1f3bb76ef70e3170e12f878aefb9c69b0fc4c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php81": "^1.22",
-                "symfony/translation-contracts": "^1.1|^2|^3"
+                "symfony/polyfill-php83": "^1.27",
+                "symfony/translation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "doctrine/annotations": "<1.13",
                 "doctrine/lexer": "<1.1",
-                "phpunit/phpunit": "<5.4.3",
                 "symfony/dependency-injection": "<5.4",
                 "symfony/expression-language": "<5.4",
                 "symfony/http-kernel": "<5.4",
@@ -67047,33 +67247,21 @@
             "require-dev": {
                 "doctrine/annotations": "^1.13|^2",
                 "egulias/email-validator": "^2.1.10|^3|^4",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "egulias/email-validator": "Strict (RFC compliant) email validation",
-                "psr/cache-implementation": "For using the mapping cache.",
-                "symfony/config": "",
-                "symfony/expression-language": "For using the Expression validator and the ExpressionLanguageSyntax constraints",
-                "symfony/http-foundation": "",
-                "symfony/intl": "",
-                "symfony/property-access": "For accessing properties within comparison constraints",
-                "symfony/property-info": "To automatically add NotNull and Type constraints",
-                "symfony/translation": "For translating validation errors.",
-                "symfony/yaml": ""
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -67101,7 +67289,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v6.0.19"
+                "source": "https://github.com/symfony/validator/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -67117,41 +67305,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-15T17:21:41+00:00"
+            "time": "2023-11-29T07:47:42+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "eb980457fa6899840fe1687e8627a03a7d8a3d52"
+                "reference": "c40f7d17e91d8b407582ed51a2bbf83c52c367f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/eb980457fa6899840fe1687e8627a03a7d8a3d52",
-                "reference": "eb980457fa6899840fe1687e8627a03a7d8a3d52",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c40f7d17e91d8b407582ed51a2bbf83c52c367f6",
+                "reference": "c40f7d17e91d8b407582ed51a2bbf83c52c367f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.3",
                 "symfony/console": "<5.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^6.3|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/uid": "^5.4|^6.0|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
-            },
-            "suggest": {
-                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
-                "ext-intl": "To show region name in time zone dump",
-                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
             },
             "bin": [
                 "Resources/bin/var-dump-server"
@@ -67189,7 +67374,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.0.19"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -67205,27 +67390,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-11-09T08:28:32+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.0.19",
+            "version": "v7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "df56f53818c2d5d9f683f4ad2e365ba73a3b69d2"
+                "reference": "a3d7c877414fcd59ab7075ecdc3b8f9c00f7bcc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/df56f53818c2d5d9f683f4ad2e365ba73a3b69d2",
-                "reference": "df56f53818c2d5d9f683f4ad2e365ba73a3b69d2",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/a3d7c877414fcd59ab7075ecdc3b8f9c00f7bcc3",
+                "reference": "a3d7c877414fcd59ab7075ecdc3b8f9c00f7bcc3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -67258,10 +67443,12 @@
                 "export",
                 "hydrate",
                 "instantiate",
+                "lazy-loading",
+                "proxy",
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.0.19"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.0.1"
             },
             "funding": [
                 {
@@ -67277,34 +67464,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-13T08:34:10+00:00"
+            "time": "2023-11-30T11:38:21+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.0.19",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "deec3a812a0305a50db8ae689b183f43d915c884"
+                "reference": "4f9237a1bb42455d609e6687d2613dde5b41a587"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/deec3a812a0305a50db8ae689b183f43d915c884",
-                "reference": "deec3a812a0305a50db8ae689b183f43d915c884",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4f9237a1bb42455d609e6687d2613dde5b41a587",
+                "reference": "4f9237a1bb42455d609e6687d2613dde5b41a587",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -67335,7 +67520,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.0.19"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.0"
             },
             "funding": [
                 {
@@ -67351,30 +67536,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T11:50:03+00:00"
+            "time": "2023-11-06T11:00:25+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.6.1",
+            "version": "v3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd"
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
-                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.22"
             },
             "require-dev": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -67410,7 +67596,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.6.1"
+                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
             },
             "funding": [
                 {
@@ -67422,7 +67608,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-08T12:52:13+00:00"
+            "time": "2023-11-21T18:54:41+00:00"
         },
         {
             "name": "voku/anti-xss",
@@ -69119,16 +69305,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.15.2",
+            "version": "2.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73"
+                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
-                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/a139776fa3f5985a50b509f2a02ff0f709d2a546",
+                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546",
                 "shasum": ""
             },
             "require": {
@@ -69178,7 +69364,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.15.2"
+                "source": "https://github.com/filp/whoops/tree/2.15.4"
             },
             "funding": [
                 {
@@ -69186,7 +69372,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-12T12:00:00+00:00"
+            "time": "2023-11-03T12:00:00+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -70322,24 +70508,27 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d"
+                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
-                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
+                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1.0",
                 "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.13"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.1",
@@ -70371,9 +70560,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.3"
             },
-            "time": "2022-10-14T12:47:21+00:00"
+            "time": "2023-08-12T11:01:26+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -70460,16 +70649,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.22.1",
+            "version": "1.24.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0"
+                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/65c39594fbd8c67abfc68bb323f86447bab79cc0",
-                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6bd0c26f3786cd9b7c359675cb789e35a8e07496",
+                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496",
                 "shasum": ""
             },
             "require": {
@@ -70501,9 +70690,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.22.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.4"
             },
-            "time": "2023-06-29T20:46:06+00:00"
+            "time": "2023-11-26T18:29:22+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0507c7b30876f5fece096af1d189eb8f",
+    "content-hash": "51979f1d70a5bbf4753af5f9f9b49a41",
     "packages": [
         {
             "name": "async-aws/core",
@@ -35233,16 +35233,16 @@
         },
         {
             "name": "spryker/merchant-product-offer-storage",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/merchant-product-offer-storage.git",
-                "reference": "29b4d1fd4edf9c977c0a8440e28a395642d67691"
+                "reference": "569a019e42d1a226bae545c660471c56498fdbd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/merchant-product-offer-storage/zipball/29b4d1fd4edf9c977c0a8440e28a395642d67691",
-                "reference": "29b4d1fd4edf9c977c0a8440e28a395642d67691",
+                "url": "https://api.github.com/repos/spryker/merchant-product-offer-storage/zipball/569a019e42d1a226bae545c660471c56498fdbd7",
+                "reference": "569a019e42d1a226bae545c660471c56498fdbd7",
                 "shasum": ""
             },
             "require": {
@@ -35253,10 +35253,12 @@
                 "spryker/merchant-product-offer": "^1.0.0",
                 "spryker/merchant-product-offer-storage-extension": "^1.1.0",
                 "spryker/product-offer": "^1.0.0 ",
+                "spryker/product-offer-service-point-storage-extension": "^1.0.0",
                 "spryker/product-offer-storage": "^1.0.0",
                 "spryker/product-offer-storage-extension": "^1.0.0",
                 "spryker/propel-orm": "^1.0.0",
-                "spryker/publisher-extension": "^1.0.0"
+                "spryker/publisher-extension": "^1.0.0",
+                "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
@@ -35288,9 +35290,9 @@
             ],
             "description": "MerchantProductOfferStorage module",
             "support": {
-                "source": "https://github.com/spryker/merchant-product-offer-storage/tree/2.0.1"
+                "source": "https://github.com/spryker/merchant-product-offer-storage/tree/2.1.0"
             },
-            "time": "2023-03-31T19:36:11+00:00"
+            "time": "2023-07-04T11:30:17+00:00"
         },
         {
             "name": "spryker/merchant-product-offer-storage-extension",
@@ -47393,16 +47395,16 @@
         },
         {
             "name": "spryker/product-offer",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-offer.git",
-                "reference": "0a6eff948e80fecf8179fd48999e1a081efa5017"
+                "reference": "3cc531ad5c86deee94a625e13dd0fba9fe2657fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-offer/zipball/0a6eff948e80fecf8179fd48999e1a081efa5017",
-                "reference": "0a6eff948e80fecf8179fd48999e1a081efa5017",
+                "url": "https://api.github.com/repos/spryker/product-offer/zipball/3cc531ad5c86deee94a625e13dd0fba9fe2657fd",
+                "reference": "3cc531ad5c86deee94a625e13dd0fba9fe2657fd",
                 "shasum": ""
             },
             "require": {
@@ -47449,9 +47451,9 @@
             ],
             "description": "ProductOffer module",
             "support": {
-                "source": "https://github.com/spryker/product-offer/tree/1.8.0"
+                "source": "https://github.com/spryker/product-offer/tree/1.9.0"
             },
-            "time": "2023-05-15T10:55:04+00:00"
+            "time": "2023-07-04T11:30:17+00:00"
         },
         {
             "name": "spryker/product-offer-availabilities-rest-api",
@@ -48159,6 +48161,47 @@
             "time": "2022-04-26T16:30:57+00:00"
         },
         {
+            "name": "spryker/product-offer-service-point-storage-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/product-offer-service-point-storage-extension.git",
+                "reference": "ea362ffc333566b12071fc3559cd976ad365975c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/product-offer-service-point-storage-extension/zipball/ea362ffc333566b12071fc3559cd976ad365975c",
+                "reference": "ea362ffc333566b12071fc3559cd976ad365975c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "ProductOfferServicePointStorageExtension module",
+            "support": {
+                "source": "https://github.com/spryker/product-offer-service-point-storage-extension/tree/1.0.0"
+            },
+            "time": "2023-07-04T11:30:17+00:00"
+        },
+        {
             "name": "spryker/product-offer-shopping-list",
             "version": "1.0.1",
             "source": {
@@ -48491,24 +48534,24 @@
         },
         {
             "name": "spryker/product-offer-storage",
-            "version": "1.3.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-offer-storage.git",
-                "reference": "d164a75a0fea657406a137a4dfe881e7d932a33a"
+                "reference": "fe325fb270a6958c53a788ba5f34376256f6e4b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-offer-storage/zipball/d164a75a0fea657406a137a4dfe881e7d932a33a",
-                "reference": "d164a75a0fea657406a137a4dfe881e7d932a33a",
+                "url": "https://api.github.com/repos/spryker/product-offer-storage/zipball/fe325fb270a6958c53a788ba5f34376256f6e4b6",
+                "reference": "fe325fb270a6958c53a788ba5f34376256f6e4b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "spryker/event-behavior": "^1.14.0",
                 "spryker/kernel": "^3.33.0",
                 "spryker/product": "^6.0.0",
-                "spryker/product-offer": "^1.5.0",
+                "spryker/product-offer": "^1.9.0",
                 "spryker/product-offer-storage-extension": "^1.0.0",
                 "spryker/product-storage-extension": "^1.4.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -48518,7 +48561,7 @@
                 "spryker/synchronization": "^1.0.0",
                 "spryker/synchronization-behavior": "^1.0.0",
                 "spryker/synchronization-extension": "^1.1.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-encoding": "^2.0.0"
             },
             "require-dev": {
@@ -48547,9 +48590,9 @@
             ],
             "description": "ProductOfferStorage module",
             "support": {
-                "source": "https://github.com/spryker/product-offer-storage/tree/1.3.0"
+                "source": "https://github.com/spryker/product-offer-storage/tree/1.5.0"
             },
-            "time": "2023-02-14T07:21:59+00:00"
+            "time": "2023-12-07T11:04:28+00:00"
         },
         {
             "name": "spryker/product-offer-storage-extension",

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -851,3 +851,24 @@ $config[GlueJsonApiConventionConstants::GLUE_DOMAIN] = sprintf(
 );
 
 $config[GlueStorefrontApiApplicationConstants::GLUE_STOREFRONT_CORS_ALLOW_ORIGIN] = getenv('SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN') ?: '*';
+
+$config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::TENANT_IDENTIFIER] = getenv('SPRYKER_TENANT_IDENTIFIER') ?: '';
+
+$config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::CHANNEL_TO_RECEIVER_TRANSPORT_MAP] = [
+    'payment-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'payment-method-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'asset-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'product-review-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'product-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'search-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'merchant-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+];
+
+$config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::CHANNEL_TO_SENDER_TRANSPORT_MAP] = [
+    'payment-commands' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'product-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'order-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'merchant-events' => \Spryker\Zed\MessageBrokerAws\MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+];
+
+$config[\Spryker\Shared\Product\ProductConstants::TENANT_IDENTIFIER] = getenv('SPRYKER_TENANT_IDENTIFIER') ?: '';

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -872,3 +872,5 @@ $config[\Spryker\Shared\MessageBroker\MessageBrokerConstants::CHANNEL_TO_SENDER_
 ];
 
 $config[\Spryker\Shared\Product\ProductConstants::TENANT_IDENTIFIER] = getenv('SPRYKER_TENANT_IDENTIFIER') ?: '';
+
+$config[\Spryker\Shared\Payment\PaymentConstants::TENANT_IDENTIFIER] = getenv('SPRYKER_TENANT_IDENTIFIER') ?: '';

--- a/data/import/common/common/glossary.csv
+++ b/data/import/common/common/glossary.csv
@@ -3969,3 +3969,7 @@ category.validation.category_node_entity_not_found,The category node ID '%catego
 category.validation.category_node_entity_not_found,"Die Kategorieknoten-ID '%category_node_id%' kann nicht verschoben werden, da dieser Kategorieknoten nicht mehr existiert.",de_DE
 store.validation.store_not_found,Store not found,en_US
 store.validation.store_not_found,Store nicht gefunden,de_DE
+page.checkout.address.single_address,Single address,en_US
+page.checkout.address.single_address,Eine Adresse,de_DE
+page.checkout.address.multiple_addresses,Multiple addresses,en_US
+page.checkout.address.multiple_addresses,Mehrere Adressen,de_DE

--- a/data/import/common/common/glossary.csv
+++ b/data/import/common/common/glossary.csv
@@ -3965,3 +3965,7 @@ permission.name.SeeCompanyUsersPermissionPlugin,View company users,en_US
 permission.name.SeeCompanyUsersPermissionPlugin,Firmenbenutzer anzeigen,de_DE
 store_widget.switcher.store,Store:,en_US
 store_widget.switcher.store,Shop:,de_DE
+category.validation.category_node_entity_not_found,The category node ID '%category_node_id%' cannot be relocated because this category node no longer exists.,en_US
+category.validation.category_node_entity_not_found,"Die Kategorieknoten-ID '%category_node_id%' kann nicht verschoben werden, da dieser Kategorieknoten nicht mehr existiert.",de_DE
+store.validation.store_not_found,Store not found,en_US
+store.validation.store_not_found,Store nicht gefunden,de_DE

--- a/src/Pyz/Service/Shipment/ShipmentConfig.php
+++ b/src/Pyz/Service/Shipment/ShipmentConfig.php
@@ -17,6 +17,6 @@ class ShipmentConfig extends SprykerShipmentConfig
      */
     public function getShipmentHashFields(): array
     {
-        return array_merge(parent::getShipmentHashFields(), [ShipmentTransfer::MERCHANT_REFERENCE]);
+        return array_merge(parent::getShipmentHashFields(), [ShipmentTransfer::MERCHANT_REFERENCE, \Generated\Shared\Transfer\ShipmentTransfer::SHIPMENT_TYPE_UUID]);
     }
 }

--- a/src/Pyz/Yves/CustomerPage/CustomerPageConfig.php
+++ b/src/Pyz/Yves/CustomerPage/CustomerPageConfig.php
@@ -11,6 +11,7 @@ use SprykerShop\Yves\CustomerPage\CustomerPageConfig as SprykerCustomerPageConfi
 
 class CustomerPageConfig extends SprykerCustomerPageConfig
 {
+    protected const CUSTOMER_SECURITY_BLOCKER_ENABLED = true;
     /**
      * @uses \Pyz\Zed\Customer\CustomerConfig::MIN_LENGTH_CUSTOMER_PASSWORD
      *

--- a/src/Pyz/Zed/Comment/CommentDependencyProvider.php
+++ b/src/Pyz/Zed/Comment/CommentDependencyProvider.php
@@ -19,7 +19,6 @@ class CommentDependencyProvider extends SprykerCommentDependencyProvider
     protected function getCommentValidatorPlugins(): array
     {
         return [
-            new QuoteCommentValidatorPlugin(),
             new SharedCartCommentValidatorPlugin(),
         ];
     }

--- a/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
+++ b/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
@@ -393,6 +393,7 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
             new MessageBrokerWorkerConsole(),
             new ScopeCacheCollectorConsole(),
             new DateTimeProductConfiguratorBuildFrontendConsole(),
+            new Spryker\Zed\Router\Communication\Plugin\Console\RouterCacheWarmUpConsole(),
         ];
 
         $propelCommands = $container->getLocator()->propel()->facade()->getConsoleCommands();

--- a/src/Pyz/Zed/Customer/CustomerConfig.php
+++ b/src/Pyz/Zed/Customer/CustomerConfig.php
@@ -11,6 +11,7 @@ use Spryker\Zed\Customer\CustomerConfig as SprykerCustomerConfig;
 
 class CustomerConfig extends SprykerCustomerConfig
 {
+    protected const PASSWORD_RESET_EXPIRATION_IS_ENABLED = true;
     /**
      * @var int
      */

--- a/src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php
+++ b/src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php
@@ -113,4 +113,17 @@ class EventDispatcherDependencyProvider extends SprykerEventDispatcherDependency
             new AutoloaderCacheEventDispatcherPlugin(),
         ];
     }
+    /**
+     * @return array
+     */
+    public function getBackofficeEventDispatcherPlugins() : array
+    {
+        return [
+            new Spryker\Zed\Application\Communication\Plugin\EventDispatcher\HeadersSecurityEventDispatcherPlugin(),
+            new Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RouterLocaleEventDispatcherPlugin(),
+            new Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RouterListenerEventDispatcherPlugin(),
+            new Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RouterSslRedirectEventDispatcherPlugin(),
+            new Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RequestAttributesEventDispatcherPlugin(),
+        ];
+    }
 }

--- a/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
+++ b/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
@@ -77,16 +77,15 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
             new PaymentReservationCanceledMessageHandlerPlugin(),
             new PaymentRefundedMessageHandlerPlugin(),
             new PaymentRefundFailedMessageHandlerPlugin(),
-            new PaymentMethodAddedMessageHandlerPlugin(),
-            new PaymentMethodDeletedMessageHandlerPlugin(),
             new AssetAddedMessageHandlerPlugin(),
             new AssetUpdatedMessageHandlerPlugin(),
             new AssetDeletedMessageHandlerPlugin(),
             new ProductReviewAddReviewsMessageHandlerPlugin(),
             new SearchEndpointAvailableMessageHandlerPlugin(),
             new SearchEndpointRemovedMessageHandlerPlugin(),
-            new MerchantExportMerchantsMessageHandlerPlugin(),
             new Spryker\Zed\Product\Communication\Plugin\MessageBroker\ProductExportMessageHandlerPlugin(),
+            new Spryker\Zed\Merchant\Communication\Plugin\MessageBroker\MerchantMessageHandlerPlugin(),
+            new Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentMethodMessageHandlerPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
+++ b/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
@@ -82,11 +82,11 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
             new AssetAddedMessageHandlerPlugin(),
             new AssetUpdatedMessageHandlerPlugin(),
             new AssetDeletedMessageHandlerPlugin(),
-            new InitializeProductExportMessageHandlerPlugin(),
             new ProductReviewAddReviewsMessageHandlerPlugin(),
             new SearchEndpointAvailableMessageHandlerPlugin(),
             new SearchEndpointRemovedMessageHandlerPlugin(),
             new MerchantExportMerchantsMessageHandlerPlugin(),
+            new Spryker\Zed\Product\Communication\Plugin\MessageBroker\ProductExportMessageHandlerPlugin(),
         ];
     }
 
@@ -98,10 +98,10 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
         return [
             new CorrelationIdMessageAttributeProviderPlugin(),
             new TimestampMessageAttributeProviderPlugin(),
-            new CurrentStoreReferenceMessageAttributeProviderPlugin(),
             new AccessTokenMessageAttributeProviderPlugin(),
             new TransactionIdMessageAttributeProviderPlugin(),
             new SessionTrackingIdMessageAttributeProviderPlugin(),
+            new Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TenantActorMessageAttributeProviderPlugin(),
         ];
     }
 
@@ -112,16 +112,6 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
     {
         return [
             new ValidationMiddlewarePlugin(),
-        ];
-    }
-
-    /**
-     * @return array<\Spryker\Zed\MessageBrokerExtension\Dependency\Plugin\MessageValidatorPluginInterface>
-     */
-    public function getExternalValidatorPlugins(): array
-    {
-        return [
-            new StoreReferenceMessageValidatorPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/OauthClient/OauthClientDependencyProvider.php
+++ b/src/Pyz/Zed/OauthClient/OauthClientDependencyProvider.php
@@ -32,7 +32,6 @@ class OauthClientDependencyProvider extends SprykerOauthClientDependencyProvider
     protected function getAccessTokenRequestExpanderPlugins(): array
     {
         return [
-            new CurrentStoreReferenceAccessTokenRequestExpanderPlugin(),
             new CacheKeySeedAccessTokenRequestExpanderPlugin(),
         ];
     }

--- a/src/Pyz/Zed/ProductBundle/ProductBundleConfig.php
+++ b/src/Pyz/Zed/ProductBundle/ProductBundleConfig.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\ProductBundle;
+
+use Spryker\Zed\ProductBundle\ProductBundleConfig as SprykerProductBundleConfig;
+
+class ProductBundleConfig extends SprykerProductBundleConfig
+{
+    /**
+     * Specification:
+     * - Defines a list of allowed fields to be copied from a source bundle item to destination bundled items.
+     *
+     * @api
+     *
+     * @return list<string>
+     */
+    public function getAllowedBundleItemFieldsToCopy() : array
+    {
+        return [
+            \Generated\Shared\Transfer\ItemTransfer::SHIPMENT,
+        ];
+    }
+}

--- a/src/Pyz/Zed/Router/RouterDependencyProvider.php
+++ b/src/Pyz/Zed/Router/RouterDependencyProvider.php
@@ -51,4 +51,14 @@ class RouterDependencyProvider extends SprykerRouterDependencyProvider
             new MerchantPortalRouterPlugin(),
         ];
     }
+    /**
+     * @return array<\Spryker\Zed\RouterExtension\Dependency\Plugin\RouterPluginInterface>
+     */
+    protected function getRouterPlugins() : array
+    {
+        return [
+            new Spryker\Zed\Router\Communication\Plugin\Router\ZedRouterPlugin(),
+            new Spryker\Zed\Router\Communication\Plugin\Router\ZedDevelopmentRouterPlugin(),
+        ];
+    }
 }

--- a/src/Pyz/Zed/SecurityGui/SecurityGuiConfig.php
+++ b/src/Pyz/Zed/SecurityGui/SecurityGuiConfig.php
@@ -11,6 +11,7 @@ use Spryker\Zed\SecurityGui\SecurityGuiConfig as SprykerSecurityGuiConfig;
 
 class SecurityGuiConfig extends SprykerSecurityGuiConfig
 {
+    protected const IS_BACKOFFICE_USER_SECURITY_BLOCKER_ENABLED = true;
     /**
      * @var string
      */

--- a/src/Pyz/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiConfig.php
+++ b/src/Pyz/Zed/SecurityMerchantPortalGui/SecurityMerchantPortalGuiConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\SecurityMerchantPortalGui;
+
+use Spryker\Zed\SecurityMerchantPortalGui\SecurityMerchantPortalGuiConfig as SprykerSecurityMerchantPortalGuiConfig;
+
+class SecurityMerchantPortalGuiConfig extends SprykerSecurityMerchantPortalGuiConfig
+{
+    protected const MERCHANT_PORTAL_SECURITY_BLOCKER_ENABLED = true;
+}

--- a/src/Pyz/Zed/Shipment/ShipmentConfig.php
+++ b/src/Pyz/Zed/Shipment/ShipmentConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\Shipment;
+
+use Spryker\Zed\Shipment\ShipmentConfig as SprykerShipmentConfig;
+
+class ShipmentConfig extends SprykerShipmentConfig
+{
+    /**
+     * Specification:
+     * - If set to `true` a stack of {@link \Spryker\Zed\CalculationExtension\Dependency\Plugin\QuotePostRecalculatePluginStrategyInterface} will be executed after quote recalculation.
+     * - Impacts {@link \Spryker\Zed\Shipment\Business\ShipmentFacade::expandQuoteWithShipmentGroups()} method.
+     *
+     * @api
+     *
+     * @return bool
+     */
+    public function shouldExecuteQuotePostRecalculationPlugins() : bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Upgrader installed 6 release group(s) (including 5 security fix(es)) containing 158 package version(s).
| Release | Efforts saved by Upgrader | Warnings detected? |
| ------- | ---- | ------------------ |
| [Updated `npm` dependencies.](https://api.release.spryker.com/release-group/5004) |0% |Yes :warning: |
| [Update npm dependency.](https://api.release.spryker.com/release-group/5089) |0% |Yes :warning: |
| [Fixed Insecure Password Reset Workflow](https://api.release.spryker.com/release-group/5137) |89% |Yes :warning: |
| [Improved controllers input validation.](https://api.release.spryker.com/release-group/5152) |100% |Yes :warning: |
| [Fixed handling of company role permissions changes](https://api.release.spryker.com/release-group/5158) |100% |Yes :warning: |
| [Expand Product offers in storage with Service info...](https://api.release.spryker.com/release-group/4889) |98% |Yes :warning: |


## Warnings
> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:schema:copy, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:model:build, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:entity:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:schema:copy, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:model:build, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:entity:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:schema:copy, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:model:build, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:entity:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:schema:copy, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:model:build, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:entity:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:schema:copy, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:model:build, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:entity:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:schema:copy, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: propel:model:build, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

> [!IMPORTANT] 
> <b>Propel model generation failed.</b> Command: transfer:entity:generate, response: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/spryker/console/bin/console(18): require_once('/data/project/v...')
#3 /data/project/vendor/bin/console(119): include('/data/project/v...')
#4 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46

<details><summary><h4>PHP classes that became not compatible with Spryker Release</h4></summary>Switch to this branch, bootstrap your project in the development environment, open the mentioned file, and compare its correctness to the released version by Spryker.

| Composer command | Project file(s) | 
|------------------|-----------------|
'composer' 'update' 'spryker/chart:1.5.0' '--no-scripts' '--no-plugins' '--no-interaction' '-W' | <b>src/Pyz/Service/Shipment/ShipmentConfig.php</b><br>Access to constant SHIPMENT_TYPE_UUID on an unknown class Generated\Shared\Transfer\ShipmentTransfer.<br><br><b>src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php</b><br>Method Pyz\Zed\MessageBroker\MessageBrokerDependencyProvider::getMessageHandlerPlugins() should return array<Spryker\Zed\MessageBrokerExtension\Dependency\Plugin\MessageHandlerPluginInterface> but returns array<int, Pyz\Zed\MessageBroker\Spryker\Zed\Product\Communication\Plugin\MessageBroker\ProductExportMessageHandlerPlugin\|Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetAddedMessageHandlerPlugin\|Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetDeletedMessageHandlerPlugin\|Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetUpdatedMessageHandlerPlugin\|Spryker\Zed\Merchant\Communication\Plugin\MessageBroker\MerchantExportMerchantsMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentCancelReservationFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentConfirmationFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentConfirmedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentMethodAddedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentMethodDeletedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentPreauthorizationFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentPreauthorizedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentRefundedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentRefundFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentReservationCanceledMessageHandlerPlugin\|Spryker\Zed\ProductReview\Communication\Plugin\MessageBroker\ProductReviewAddReviewsMessageHandlerPlugin\|Spryker\Zed\SearchHttp\Communication\Plugin\MessageBroker\SearchEndpointAvailableMessageHandlerPlugin\|Spryker\Zed\SearchHttp\Communication\Plugin\MessageBroker\SearchEndpointRemovedMessageHandlerPlugin>.<br><br><b>src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php</b><br>Instantiated class Pyz\Zed\MessageBroker\Spryker\Zed\Product\Communication\Plugin\MessageBroker\ProductExportMessageHandlerPlugin not found.<br><br><b>src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php</b><br>Method Pyz\Zed\MessageBroker\MessageBrokerDependencyProvider::getMessageAttributeProviderPlugins() should return array<Spryker\Zed\MessageBrokerExtension\Dependency\Plugin\MessageAttributeProviderPluginInterface> but returns array<int, Pyz\Zed\MessageBroker\Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TenantActorMessageAttributeProviderPlugin\|Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\CorrelationIdMessageAttributeProviderPlugin\|Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TimestampMessageAttributeProviderPlugin\|Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TransactionIdMessageAttributeProviderPlugin\|Spryker\Zed\OauthClient\Communication\Plugin\MessageBroker\AccessTokenMessageAttributeProviderPlugin\|Spryker\Zed\Session\Communication\Plugin\MessageBroker\SessionTrackingIdMessageAttributeProviderPlugin>.<br><br><b>src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php</b><br>Instantiated class Pyz\Zed\MessageBroker\Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TenantActorMessageAttributeProviderPlugin not found.<br><br><b>src/Pyz/Zed/Router/RouterDependencyProvider.php</b><br>Method Pyz\Zed\Router\RouterDependencyProvider::getRouterPlugins() should return array<Spryker\Zed\RouterExtension\Dependency\Plugin\RouterPluginInterface> but returns array<int, Pyz\Zed\Router\Spryker\Zed\Router\Communication\Plugin\Router\ZedDevelopmentRouterPlugin\|Pyz\Zed\Router\Spryker\Zed\Router\Communication\Plugin\Router\ZedRouterPlugin>.<br><br><b>src/Pyz/Zed/Router/RouterDependencyProvider.php</b><br>Instantiated class Pyz\Zed\Router\Spryker\Zed\Router\Communication\Plugin\Router\ZedRouterPlugin not found.<br><br><b>src/Pyz/Zed/Router/RouterDependencyProvider.php</b><br>Instantiated class Pyz\Zed\Router\Spryker\Zed\Router\Communication\Plugin\Router\ZedDevelopmentRouterPlugin not found.<br> | 
'composer' 'update' 'spryker/security-gui:1.5.0' 'spryker/security-merchant-portal-gui:2.2.0' 'spryker/user-password-reset:1.5.0' 'spryker-shop/customer-page:2.49.0' '--no-scripts' '--no-plugins' '--no-interaction' '-W' | <b>src/Pyz/Zed/ProductBundle/ProductBundleConfig.php</b><br>Access to constant SHIPMENT on an unknown class Generated\Shared\Transfer\ItemTransfer.<br> | 
- | <b>src/Pyz/Zed/Console/ConsoleDependencyProvider.php</b><br>Instantiated class Pyz\Zed\Console\Spryker\Zed\Router\Communication\Plugin\Console\RouterCacheWarmUpConsole not found.<br><br><b>src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php</b><br>Instantiated class Pyz\Zed\EventDispatcher\Spryker\Zed\Application\Communication\Plugin\EventDispatcher\HeadersSecurityEventDispatcherPlugin not found.<br><br><b>src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php</b><br>Instantiated class Pyz\Zed\EventDispatcher\Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RouterLocaleEventDispatcherPlugin not found.<br><br><b>src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php</b><br>Instantiated class Pyz\Zed\EventDispatcher\Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RouterListenerEventDispatcherPlugin not found.<br><br><b>src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php</b><br>Instantiated class Pyz\Zed\EventDispatcher\Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RouterSslRedirectEventDispatcherPlugin not found.<br><br><b>src/Pyz/Zed/EventDispatcher/EventDispatcherDependencyProvider.php</b><br>Instantiated class Pyz\Zed\EventDispatcher\Spryker\Zed\Router\Communication\Plugin\EventDispatcher\RequestAttributesEventDispatcherPlugin not found.<br><br><b>src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php</b><br>Method Pyz\Zed\MessageBroker\MessageBrokerDependencyProvider::getMessageHandlerPlugins() should return array<Spryker\Zed\MessageBrokerExtension\Dependency\Plugin\MessageHandlerPluginInterface> but returns array<int, Pyz\Zed\MessageBroker\Spryker\Zed\Merchant\Communication\Plugin\MessageBroker\MerchantMessageHandlerPlugin\|Pyz\Zed\MessageBroker\Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentMethodMessageHandlerPlugin\|Pyz\Zed\MessageBroker\Spryker\Zed\Product\Communication\Plugin\MessageBroker\ProductExportMessageHandlerPlugin\|Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetAddedMessageHandlerPlugin\|Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetDeletedMessageHandlerPlugin\|Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetUpdatedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentCancelReservationFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentConfirmationFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentConfirmedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentPreauthorizationFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentPreauthorizedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentRefundedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentRefundFailedMessageHandlerPlugin\|Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentReservationCanceledMessageHandlerPlugin\|Spryker\Zed\ProductReview\Communication\Plugin\MessageBroker\ProductReviewAddReviewsMessageHandlerPlugin\|Spryker\Zed\SearchHttp\Communication\Plugin\MessageBroker\SearchEndpointAvailableMessageHandlerPlugin\|Spryker\Zed\SearchHttp\Communication\Plugin\MessageBroker\SearchEndpointRemovedMessageHandlerPlugin>.<br><br><b>src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php</b><br>Instantiated class Pyz\Zed\MessageBroker\Spryker\Zed\Merchant\Communication\Plugin\MessageBroker\MerchantMessageHandlerPlugin not found.<br><br><b>src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php</b><br>Instantiated class Pyz\Zed\MessageBroker\Spryker\Zed\Payment\Communication\Plugin\MessageBroker\PaymentMethodMessageHandlerPlugin not found.<br> | 

</details>

<details><summary><h4>We were not able to integrate these module versions</h4></summary>

| Package | Version | Message | 
|---------|------|--------|
 | **Availability** | 9.19.0 | Manifest for Spryker.Availability:9.19.0 was skipped. Target module Spryker/DynamicEntity does not exists in your system. | 
 | **files** |  P | Error during normalizing files: PHP Warning:  require(/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php): Failed to open stream: No such file or directory in /data/project/vendor/composer/autoload_real.php on line 46
PHP Fatal error:  Uncaught Error: Failed opening required '/data/project/vendor/composer/../symfony/polyfill-php81/bootstrap.php' (include_path='/data/project/vendor/spryker/synchronization-behavior/src:/data/project/vendor/spryker/event-behavior/src:/data/project/vendor/spryker/rabbit-mq/src:/data/project/vendor/spryker/architecture-sniffer/src:.:/usr/share/php7') in /data/project/vendor/composer/autoload_real.php:46
Stack trace:
#0 /data/project/vendor/composer/autoload_real.php(50): {closure}('23c18046f52bef3...', '/data/project/v...')
#1 /data/project/vendor/autoload.php(25): ComposerAutoloaderInit0507c7b30876f5fece096af1d189eb8f::getLoader()
#2 /data/project/vendor/squizlabs/php_codesniffer/autoload.php(79): include('/data/project/v...')
#3 /data/project/vendor/squizlabs/php_codesniffer/bin/phpcbf(17): PHP_CodeSniffer\Autoload::load('PHP_CodeSniffer...')
#4 /data/project/vendor/bin/phpcbf(119): include('/data/project/v...')
#5 {main}
  thrown in /data/project/vendor/composer/autoload_real.php on line 46 | 
 | **MerchantProductOfferStorage** | 2.1.0 | Manifest for Spryker.MerchantProductOfferStorage:2.1.0 was skipped. Target module Spryker/ProductOfferServicePointStorage does not exists in your system. | 
</details>


<details><summary><h2>List of packages</h2></summary>

**Packages upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **composer/semver** | 3.3.2 | 3.4.0 | https://github.com/composer/semver/compare/3.3.2...3.4.0 | 
 | **doctrine/deprecations** | v1.1.1 | 1.1.2 | https://github.com/doctrine/deprecations/compare/v1.1.1...1.1.2 | 
 | **guzzlehttp/guzzle** | 7.7.0 | 7.8.1 | https://github.com/guzzle/guzzle/compare/7.7.0...7.8.1 | 
 | **guzzlehttp/psr7** | 2.5.0 | 2.6.2 | https://github.com/guzzle/psr7/compare/2.5.0...2.6.2 | 
 | **laminas/laminas-config** | 3.8.0 | 3.9.0 | https://github.com/laminas/laminas-config/compare/3.8.0...3.9.0 | 
 | **laminas/laminas-filter** | 2.31.0 | 2.33.0 | https://github.com/laminas/laminas-filter/compare/2.31.0...2.33.0 | 
 | **laminas/laminas-servicemanager** | 3.20.0 | 3.22.1 | https://github.com/laminas/laminas-servicemanager/compare/3.20.0...3.22.1 | 
 | **laminas/laminas-stdlib** | 3.16.1 | 3.18.0 | https://github.com/laminas/laminas-stdlib/compare/3.16.1...3.18.0 | 
 | **league/csv** | 9.8.0 | 9.12.0 | https://github.com/thephpleague/csv/compare/9.8.0...9.12.0 | 
 | **monolog/monolog** | 2.9.1 | 2.9.2 | https://github.com/Seldaek/monolog/compare/2.9.1...2.9.2 | 
 | **psr/http-client** | 1.0.2 | 1.0.3 | https://github.com/php-fig/http-client/compare/1.0.2...1.0.3 | 
 | **ramsey/uuid** | 4.7.4 | 4.7.5 | https://github.com/ramsey/uuid/compare/4.7.4...4.7.5 | 
 | **react/promise** | v2.10.0 | v2.11.0 | https://github.com/reactphp/promise/compare/v2.10.0...v2.11.0 | 
 | **spryker-sdk/evaluator** | 0.1.3 | 0.1.15 | https://github.com/spryker-sdk/evaluator/compare/0.1.3...0.1.15 | 
 | **spryker/acl** | 3.17.1 | 3.18.0 | https://github.com/spryker/acl/compare/3.17.1...3.18.0 | 
 | **spryker/application** | 3.32.1 | 3.35.0 | https://github.com/spryker/application/compare/3.32.1...3.35.0 | 
 | **spryker/authorization-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/authorization-extension/compare/1.1.0...1.2.0 | 
 | **spryker/availability** | 9.18.0 | 9.21.0 | https://github.com/spryker/availability/compare/9.18.0...9.21.0 | 
 | **spryker/category** | 5.13.0 | 5.15.1 | https://github.com/spryker/category/compare/5.13.0...5.15.1 | 
 | **spryker/chart** | 1.4.0 | 1.5.0 | https://github.com/spryker/chart/compare/1.4.0...1.5.0 | 
 | **spryker/checkout** | 6.4.4 | 6.5.0 | https://github.com/spryker/checkout/compare/6.4.4...6.5.0 | 
 | **spryker/collector** | 6.8.0 | 6.10.0 | https://github.com/spryker/collector/compare/6.8.0...6.10.0 | 
 | **spryker/config** | 3.6.0 | 3.7.0 | https://github.com/spryker/config/compare/3.6.0...3.7.0 | 
 | **spryker/customer** | 7.51.4 | 7.54.0 | https://github.com/spryker/customer/compare/7.51.4...7.54.0 | 
 | **spryker/customer-extension** | 1.4.0 | 1.5.0 | https://github.com/spryker/customer-extension/compare/1.4.0...1.5.0 | 
 | **spryker/discount** | 9.34.0 | 9.35.0 | https://github.com/spryker/discount/compare/9.34.0...9.35.0 | 
 | **spryker/error-handler** | 2.8.1 | 2.9.0 | https://github.com/spryker/error-handler/compare/2.8.1...2.9.0 | 
 | **spryker/event-behavior** | 1.25.0 | 1.27.0 | https://github.com/spryker/event-behavior/compare/1.25.0...1.27.0 | 
 | **spryker/glossary** | 3.14.0 | 3.16.0 | https://github.com/spryker/glossary/compare/3.14.0...3.16.0 | 
 | **spryker/glossary-storage** | 1.11.1 | 1.11.2 | https://github.com/spryker/glossary-storage/compare/1.11.1...1.11.2 | 
 | **spryker/gui** | 3.49.2 | 3.52.1 | https://github.com/spryker/gui/compare/3.49.2...3.52.1 | 
 | **spryker/installer** | 4.1.0 | 4.2.0 | https://github.com/spryker/installer/compare/4.1.0...4.2.0 | 
 | **spryker/kernel** | 3.73.0 | 3.74.0 | https://github.com/spryker/kernel/compare/3.73.0...3.74.0 | 
 | **spryker/locale** | 4.1.0 | 4.2.0 | https://github.com/spryker/locale/compare/4.1.0...4.2.0 | 
 | **spryker/log** | 3.15.0 | 3.16.0 | https://github.com/spryker/log/compare/3.15.0...3.16.0 | 
 | **spryker/message-broker** | 1.7.0 | 1.10.0 | https://github.com/spryker/message-broker/compare/1.7.0...1.10.0 | 
 | **spryker/message-broker-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/message-broker-extension/compare/1.1.0...1.2.0 | 
 | **spryker/money** | 2.12.0 | 2.13.0 | https://github.com/spryker/money/compare/2.12.0...2.13.0 | 
 | **spryker/oms** | 11.26.5 | 11.28.0 | https://github.com/spryker/oms/compare/11.26.5...11.28.0 | 
 | **spryker/product** | 6.36.3 | 6.38.0 | https://github.com/spryker/product/compare/6.36.3...6.38.0 | 
 | **spryker/product-category** | 4.21.0 | 4.22.0 | https://github.com/spryker/product-category/compare/4.21.0...4.22.0 | 
 | **spryker/product-image** | 3.16.0 | 3.17.0 | https://github.com/spryker/product-image/compare/3.16.0...3.17.0 | 
 | **spryker/product-option** | 8.15.2 | 8.16.0 | https://github.com/spryker/product-option/compare/8.15.2...8.16.0 | 
 | **spryker/product-search** | 5.19.0 | 5.21.0 | https://github.com/spryker/product-search/compare/5.19.0...5.21.0 | 
 | **spryker/propel** | 3.38.0 | 3.39.0 | https://github.com/spryker/propel/compare/3.38.0...3.39.0 | 
 | **spryker/queue** | 1.9.3 | 1.10.0 | https://github.com/spryker/queue/compare/1.9.3...1.10.0 | 
 | **spryker/quote** | 2.18.0 | 2.19.0 | https://github.com/spryker/quote/compare/2.18.0...2.19.0 | 
 | **spryker/redis** | 2.6.1 | 2.7.0 | https://github.com/spryker/redis/compare/2.6.1...2.7.0 | 
 | **spryker/refund** | 5.7.2 | 5.8.0 | https://github.com/spryker/refund/compare/5.7.2...5.8.0 | 
 | **spryker/router** | 1.15.1 | 1.18.0 | https://github.com/spryker/router/compare/1.15.1...1.18.0 | 
 | **spryker/sales** | 11.40.5 | 11.44.0 | https://github.com/spryker/sales/compare/11.40.5...11.44.0 | 
 | **spryker/sales-extension** | 1.9.0 | 1.10.0 | https://github.com/spryker/sales-extension/compare/1.9.0...1.10.0 | 
 | **spryker/sales-split** | 5.1.1 | 5.2.0 | https://github.com/spryker/sales-split/compare/5.1.1...5.2.0 | 
 | **spryker/search** | 8.20.0 | 8.22.0 | https://github.com/spryker/search/compare/8.20.0...8.22.0 | 
 | **spryker/search-extension** | 1.2.0 | 1.3.0 | https://github.com/spryker/search-extension/compare/1.2.0...1.3.0 | 
 | **spryker/session** | 4.15.1 | 4.16.0 | https://github.com/spryker/session/compare/4.15.1...4.16.0 | 
 | **spryker/shipment** | 8.15.2 | 8.19.0 | https://github.com/spryker/shipment/compare/8.15.2...8.19.0 | 
 | **spryker/shipment-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/shipment-extension/compare/1.1.0...1.2.0 | 
 | **spryker/step-engine** | 3.4.3 | 3.5.0 | https://github.com/spryker/step-engine/compare/3.4.3...3.5.0 | 
 | **spryker/stock** | 8.8.2 | 8.8.3 | https://github.com/spryker/stock/compare/8.8.2...8.8.3 | 
 | **spryker/storage** | 3.20.1 | 3.22.0 | https://github.com/spryker/storage/compare/3.20.1...3.22.0 | 
 | **spryker/store** | 1.20.0 | 1.24.0 | https://github.com/spryker/store/compare/1.20.0...1.24.0 | 
 | **spryker/symfony** | 3.12.0 | 3.14.0 | https://github.com/spryker/symfony/compare/3.12.0...3.14.0 | 
 | **spryker/tax** | 5.14.0 | 5.15.0 | https://github.com/spryker/tax/compare/5.14.0...5.15.0 | 
 | **spryker/touch** | 4.6.0 | 4.7.0 | https://github.com/spryker/touch/compare/4.6.0...4.7.0 | 
 | **spryker/transfer** | 3.33.1 | 3.35.0 | https://github.com/spryker/transfer/compare/3.33.1...3.35.0 | 
 | **spryker/translator** | 1.11.0 | 1.13.0 | https://github.com/spryker/translator/compare/1.11.0...1.13.0 | 
 | **spryker/twig** | 3.18.1 | 3.19.0 | https://github.com/spryker/twig/compare/3.18.1...3.19.0 | 
 | **spryker/user** | 3.18.0 | 3.19.0 | https://github.com/spryker/user/compare/3.18.0...3.19.0 | 
 | **spryker/util-date-time** | 1.4.0 | 1.4.1 | https://github.com/spryker/util-date-time/compare/1.4.0...1.4.1 | 
 | **spryker/util-text** | 1.5.1 | 1.6.0 | https://github.com/spryker/util-text/compare/1.5.1...1.6.0 | 
 | **spryker/zed-request** | 3.19.0 | 3.20.0 | https://github.com/spryker/zed-request/compare/3.19.0...3.20.0 | 
 | **symfony/cache** | v6.0.19 | v6.4.0 | https://github.com/symfony/cache/compare/v6.0.19...v6.4.0 | 
 | **symfony/cache-contracts** | v3.0.2 | v3.4.0 | https://github.com/symfony/cache-contracts/compare/v3.0.2...v3.4.0 | 
 | **symfony/console** | v6.0.19 | v6.4.1 | https://github.com/symfony/console/compare/v6.0.19...v6.4.1 | 
 | **symfony/dependency-injection** | v6.0.20 | v6.4.1 | https://github.com/symfony/dependency-injection/compare/v6.0.20...v6.4.1 | 
 | **symfony/deprecation-contracts** | v3.0.2 | v3.4.0 | https://github.com/symfony/deprecation-contracts/compare/v3.0.2...v3.4.0 | 
 | **symfony/dotenv** | v6.0.19 | v6.4.0 | https://github.com/symfony/dotenv/compare/v6.0.19...v6.4.0 | 
 | **symfony/error-handler** | v6.0.19 | v6.4.0 | https://github.com/symfony/error-handler/compare/v6.0.19...v6.4.0 | 
 | **symfony/event-dispatcher** | v6.0.19 | v6.4.0 | https://github.com/symfony/event-dispatcher/compare/v6.0.19...v6.4.0 | 
 | **symfony/event-dispatcher-contracts** | v3.0.2 | v3.4.0 | https://github.com/symfony/event-dispatcher-contracts/compare/v3.0.2...v3.4.0 | 
 | **symfony/filesystem** | v6.0.19 | v6.4.0 | https://github.com/symfony/filesystem/compare/v6.0.19...v6.4.0 | 
 | **symfony/finder** | v6.0.19 | v6.4.0 | https://github.com/symfony/finder/compare/v6.0.19...v6.4.0 | 
 | **symfony/flex** | v2.3.1 | v2.4.2 | https://github.com/symfony/flex/compare/v2.3.1...v2.4.2 | 
 | **symfony/form** | v6.2.5 | v6.4.1 | https://github.com/symfony/form/compare/v6.2.5...v6.4.1 | 
 | **symfony/framework-bundle** | v6.0.19 | v6.2.13 | https://github.com/symfony/framework-bundle/compare/v6.0.19...v6.2.13 | 
 | **symfony/http-client** | v6.0.20 | v6.4.0 | https://github.com/symfony/http-client/compare/v6.0.20...v6.4.0 | 
 | **symfony/http-client-contracts** | v3.0.2 | v3.4.0 | https://github.com/symfony/http-client-contracts/compare/v3.0.2...v3.4.0 | 
 | **symfony/http-foundation** | v6.0.20 | v6.4.0 | https://github.com/symfony/http-foundation/compare/v6.0.20...v6.4.0 | 
 | **symfony/http-kernel** | v6.0.20 | v6.4.1 | https://github.com/symfony/http-kernel/compare/v6.0.20...v6.4.1 | 
 | **symfony/intl** | v6.0.19 | v6.4.0 | https://github.com/symfony/intl/compare/v6.0.19...v6.4.0 | 
 | **symfony/messenger** | v6.0.19 | v6.4.0 | https://github.com/symfony/messenger/compare/v6.0.19...v6.4.0 | 
 | **symfony/mime** | v6.0.19 | v6.4.0 | https://github.com/symfony/mime/compare/v6.0.19...v6.4.0 | 
 | **symfony/monolog-bridge** | v5.4.22 | v5.4.31 | https://github.com/symfony/monolog-bridge/compare/v5.4.22...v5.4.31 | 
 | **symfony/monolog-bundle** | v3.8.0 | v3.10.0 | https://github.com/symfony/monolog-bundle/compare/v3.8.0...v3.10.0 | 
 | **symfony/options-resolver** | v6.0.19 | v6.4.0 | https://github.com/symfony/options-resolver/compare/v6.0.19...v6.4.0 | 
 | **symfony/password-hasher** | v6.0.19 | v6.4.0 | https://github.com/symfony/password-hasher/compare/v6.0.19...v6.4.0 | 
 | **symfony/polyfill-intl-grapheme** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-grapheme/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-icu** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-icu/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-idn** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-idn/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-normalizer** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-normalizer/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-mbstring** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-mbstring/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php73** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php73/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php80** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php80/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php81** | v1.28.0 | REMOVED |  | 
 | **symfony/polyfill-uuid** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-uuid/compare/v1.27.0...v1.28.0 | 
 | **symfony/process** | v6.0.19 | v6.4.0 | https://github.com/symfony/process/compare/v6.0.19...v6.4.0 | 
 | **symfony/property-access** | v6.0.19 | v6.4.0 | https://github.com/symfony/property-access/compare/v6.0.19...v6.4.0 | 
 | **symfony/property-info** | v6.0.19 | v7.0.0 | https://github.com/symfony/property-info/compare/v6.0.19...v7.0.0 | 
 | **symfony/routing** | v6.0.19 | v6.4.1 | https://github.com/symfony/routing/compare/v6.0.19...v6.4.1 | 
 | **symfony/runtime** | v6.0.19 | v6.4.0 | https://github.com/symfony/runtime/compare/v6.0.19...v6.4.0 | 
 | **symfony/security-core** | v5.4.22 | v5.4.30 | https://github.com/symfony/security-core/compare/v5.4.22...v5.4.30 | 
 | **symfony/security-csrf** | v6.0.19 | v6.4.0 | https://github.com/symfony/security-csrf/compare/v6.0.19...v6.4.0 | 
 | **symfony/security-guard** | v5.4.22 | v5.4.27 | https://github.com/symfony/security-guard/compare/v5.4.22...v5.4.27 | 
 | **symfony/security-http** | v5.4.23 | v5.4.31 | https://github.com/symfony/security-http/compare/v5.4.23...v5.4.31 | 
 | **symfony/serializer** | v6.0.19 | v6.4.1 | https://github.com/symfony/serializer/compare/v6.0.19...v6.4.1 | 
 | **symfony/stopwatch** | v6.0.19 | v6.4.0 | https://github.com/symfony/stopwatch/compare/v6.0.19...v6.4.0 | 
 | **symfony/string** | v6.0.19 | v7.0.0 | https://github.com/symfony/string/compare/v6.0.19...v7.0.0 | 
 | **symfony/translation** | v6.0.19 | v6.4.0 | https://github.com/symfony/translation/compare/v6.0.19...v6.4.0 | 
 | **symfony/translation-contracts** | v3.0.2 | v3.4.0 | https://github.com/symfony/translation-contracts/compare/v3.0.2...v3.4.0 | 
 | **symfony/twig-bridge** | v6.0.19 | v6.4.0 | https://github.com/symfony/twig-bridge/compare/v6.0.19...v6.4.0 | 
 | **symfony/uid** | v6.0.19 | v6.4.0 | https://github.com/symfony/uid/compare/v6.0.19...v6.4.0 | 
 | **symfony/validator** | v6.0.19 | v6.4.0 | https://github.com/symfony/validator/compare/v6.0.19...v6.4.0 | 
 | **symfony/var-dumper** | v6.0.19 | v6.4.0 | https://github.com/symfony/var-dumper/compare/v6.0.19...v6.4.0 | 
 | **symfony/var-exporter** | v6.0.19 | v7.0.1 | https://github.com/symfony/var-exporter/compare/v6.0.19...v7.0.1 | 
 | **symfony/yaml** | v6.0.19 | v6.4.0 | https://github.com/symfony/yaml/compare/v6.0.19...v6.4.0 | 
 | **twig/twig** | v3.6.1 | v3.8.0 | https://github.com/twigphp/Twig/compare/v3.6.1...v3.8.0 | 
 | **spryker-sdk/utils** | NEW | 0.1.2 |  | 
 | **spryker/dynamic-entity-extension** | NEW | 1.0.0 |  | 
 | **spryker/willdurand-negotiation** | NEW | 1.0.0 |  | 
 | **symfony/clock** | NEW | v7.0.0 |  | 
 | **symfony/polyfill-php83** | NEW | v1.28.0 |  | 
 | **spryker/chart** | 1.5.0 | 1.6.0 | https://github.com/spryker/chart/compare/1.5.0...1.6.0 | 
 | **spryker-shop/checkout-page** | 3.24.0 | 3.30.1 | https://github.com/spryker-shop/checkout-page/compare/3.24.0...3.30.1 | 
 | **spryker-shop/checkout-page-extension** | 1.4.0 | 1.5.0 | https://github.com/spryker-shop/checkout-page-extension/compare/1.4.0...1.5.0 | 
 | **spryker-shop/customer-page** | 2.43.0 | 2.49.0 | https://github.com/spryker-shop/customer-page/compare/2.43.0...2.49.0 | 
 | **spryker-shop/customer-page-extension** | 1.5.0 | 1.6.0 | https://github.com/spryker-shop/customer-page-extension/compare/1.5.0...1.6.0 | 
 | **spryker-shop/shop-ui** | 1.71.0 | 1.73.2 | https://github.com/spryker-shop/shop-ui/compare/1.71.0...1.73.2 | 
 | **spryker/customer-access-storage** | 1.8.1 | 1.9.0 | https://github.com/spryker/customer-access-storage/compare/1.8.1...1.9.0 | 
 | **spryker/merchant** | 3.7.1 | 3.9.0 | https://github.com/spryker/merchant/compare/3.7.1...3.9.0 | 
 | **spryker/merchant-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/merchant-extension/compare/1.1.0...1.2.0 | 
 | **spryker/payment** | 5.14.1 | 5.15.1 | https://github.com/spryker/payment/compare/5.14.1...5.15.1 | 
 | **spryker/price-product** | 4.42.1 | 4.43.1 | https://github.com/spryker/price-product/compare/4.42.1...4.43.1 | 
 | **spryker/product-bundle** | 7.15.0 | 7.18.0 | https://github.com/spryker/product-bundle/compare/7.15.0...7.18.0 | 
 | **spryker/security-gui** | 1.3.0 | 1.5.0 | https://github.com/spryker/security-gui/compare/1.3.0...1.5.0 | 
 | **spryker/security-merchant-portal-gui** | 2.1.0 | 2.2.0 | https://github.com/spryker/security-merchant-portal-gui/compare/2.1.0...2.2.0 | 
 | **spryker/user-password-reset** | 1.4.0 | 1.5.0 | https://github.com/spryker/user-password-reset/compare/1.4.0...1.5.0 | 
 | **spryker/zed-ui** | 2.1.2 | 2.2.0 | https://github.com/spryker/zed-ui/compare/2.1.2...2.2.0 | 
 | **spryker/state-machine** | 2.18.0 | 2.20.0 | https://github.com/spryker/state-machine/compare/2.18.0...2.20.0 | 
 | **spryker-shop/company-page** | 2.23.0 | 2.24.0 | https://github.com/spryker-shop/company-page/compare/2.23.0...2.24.0 | 
 | **spryker/company-user** | 2.16.1 | 2.17.0 | https://github.com/spryker/company-user/compare/2.16.1...2.17.0 | 
 | **spryker/merchant-product-offer-storage** | 2.0.1 | 2.1.0 | https://github.com/spryker/merchant-product-offer-storage/compare/2.0.1...2.1.0 | 
 | **spryker/product-offer** | 1.8.0 | 1.9.0 | https://github.com/spryker/product-offer/compare/1.8.0...1.9.0 | 
 | **spryker/product-offer-storage** | 1.3.0 | 1.5.0 | https://github.com/spryker/product-offer-storage/compare/1.3.0...1.5.0 | 
 | **spryker/product-offer-service-point-storage-extension** | NEW | 1.0.0 |  | 

**Packages dev upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **filp/whoops** | 2.15.2 | 2.15.4 | https://github.com/filp/whoops/compare/2.15.2...2.15.4 | 
 | **phpdocumentor/type-resolver** | 1.6.2 | 1.7.3 | https://github.com/phpDocumentor/TypeResolver/compare/1.6.2...1.7.3 | 
 | **phpstan/phpdoc-parser** | 1.22.1 | 1.24.4 | https://github.com/phpstan/phpdoc-parser/compare/1.22.1...1.24.4 | 

</details>


### Having trouble with Upgrader and going to contact Spryker?
- Check [Upgrader docs](https://docs.spryker.com/docs/scu/dev/spryker-code-upgrader.html)
- Please copy this report ID or content of this PR and send it to us. Report ID: 6bbbdecb-00d0-4055-8b77-d84ae40017f3